### PR TITLE
Update README to suggest using npx for installation, update GitHub CI config

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -14,23 +14,10 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Compile
-        run: yarn && yarn build
-
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Set up node
-        uses: actions/setup-node@v3
-
-      - name: Compile
-        run: yarn && yarn test    
+        run: npm install && npm run build
 
   publish:
-    needs: [ compile, test ]
+    needs: [ compile ]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -39,9 +26,9 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
       - name: Install dependencies
-        run: yarn install
+        run: npm install
       - name: Build
-        run: yarn build
+        run: npm run build
 
       - name: Publish to npm
         run: |

--- a/README.md
+++ b/README.md
@@ -23,15 +23,7 @@ Node.js server implementing Model Context Protocol (MCP) for Webflow using the [
 
 _Additional documentation can be found here: https://help.webflow.com/hc/en-us/articles/33961356296723-Intro-to-Webflow-s-APIs_
 
-### 2. Build the server
-
-```shell
-cd /PATH/TO/PROJECT
-npm install
-npm run build
-```
-
-### 3. Set up your MCP client
+### 2. Set up your MCP client
 
 Add the following to the configuration file for your MCP client e.g. **Cursor, Windsurf, or Claude Desktop**:
 
@@ -39,9 +31,9 @@ Add the following to the configuration file for your MCP client e.g. **Cursor, W
 {
   "mcpServers": {
     "webflow": {
-      "command": "node",
+      "command": "npx",
       "args": [
-        "/PATH/TO/PROJECT/dist/index.js"
+        "webflow-mcp-server"
       ],
       "env": {
         "WEBFLOW_TOKEN": "..."


### PR DESCRIPTION
Also removes the test job since we don't currently have tests set up for this project.

We need to run our first CI job to actually publish `webflow-mcp-server@1.0.0` to npm.