### PR TITLE
feat: add collection create, field create, and field update tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,27 +70,32 @@ A Node.js server implementing Model Context Protocol (MCP) for Webflow using the
 
 ### Sites
 
-````ts
+```ts
 sites - list; // List all sites
 sites - get; // Get site details
 sites - publish; // Publish site changes
-````
+```
 
 ### Pages
 
-````ts
+```ts
 pages - list; // List all pages
 pages - get - metadata; // Get page metadata
 pages - update - page - settings; // Update page settings
 pages - get - content; // Get page content
 pages - update - static - content; // Update page content
-````
+```
 
 ### CMS
 
 ```ts
 collections - list; // List collections
 collections - get; // Get collection details
+collections - create; // Create a collection
+collection - fields - create - static; // Create a static field
+collection - fields - create - option; // Create an option field
+collection - fields - create - reference; // Create a reference field
+collection - fields - update; // Update a custom field
 collections - items - create - item - live; // Create items
 collections - items - update - items - live; // Update items
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A Node.js server implementing Model Context Protocol (MCP) for Webflow using the
 
 ### Sites
 
-```ts
+```
 sites - list; // List all sites
 sites - get; // Get site details
 sites - publish; // Publish site changes
@@ -78,7 +78,7 @@ sites - publish; // Publish site changes
 
 ### Pages
 
-```ts
+```
 pages - list; // List all pages
 pages - get - metadata; // Get page metadata
 pages - update - page - settings; // Update page settings
@@ -88,7 +88,7 @@ pages - update - static - content; // Update page content
 
 ### CMS
 
-```ts
+```
 collections - list; // List collections
 collections - get; // Get collection details
 collections - create; // Create a collection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webflow-mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webflow-mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "webflow-api": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-mcp-server",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,139 @@ server.tool(
   }
 );
 
+export const StaticFieldSchema = z.object({
+  id: z.string().optional(),
+  isEditable: z.boolean().optional(),
+  isRequired: z.boolean().optional(),
+  type: z.union([
+    z.literal("Color"),
+    z.literal("DateTime"),
+    z.literal("Email"),
+    z.literal("File"),
+    z.literal("Image"),
+    z.literal("Link"),
+    z.literal("MultiImage"),
+    z.literal("Number"),
+    z.literal("Phone"),
+    z.literal("PlainText"),
+    z.literal("RichText"),
+    z.literal("Switch"),
+    z.literal("Video")
+  ]),
+  displayName: z.string(),
+  helpText: z.string().optional()
+})
+
+export const OptionFieldSchema = z.object({
+  id: z.string().optional(),
+  isEditable: z.boolean().optional(),
+  isRequired: z.boolean().optional(),
+  type: z.literal("Option"),
+  displayName: z.string(),
+  helpText: z.string().optional(),
+  metadata: z.object({
+    options: z.array(
+      z.object({
+        name: z.string(),
+        id: z.string().optional()
+      })
+    )
+  })
+})
+
+export const ReferenceFieldSchema = z.object({
+  id: z.string().optional(),
+  isEditable: z.boolean().optional(),
+  isRequired: z.boolean().optional(),
+  type: z.union([z.literal("MultiReference"), z.literal("Reference")]),
+  displayName: z.string(),
+  helpText: z.string().optional(),
+  metadata: z.object({
+    collectionId: z.string()
+  })
+})
+
+// request: Webflow.CollectionsCreateRequest
+// NOTE: Cursor agent seems to struggle when provided with z.union(...), so we simplify the type here
+export const WebflowCollectionsCreateRequestSchema = z.object({
+  displayName: z.string(),
+  singularName: z.string(),
+  slug: z.string().optional(),
+})
+
+// POST https://api.webflow.com/v2/sites/:site_id/collections
+server.tool(
+  "collections_create",
+  {
+    site_id: z.string(),
+    request: WebflowCollectionsCreateRequestSchema  
+  },
+  async ({ site_id, request }) => {
+    const response = await client.collections.create(site_id, request);
+    return { content: [{ type: "text", text: JSON.stringify(response) }] };
+  }
+);
+
+// POST https://api.webflow.com/v2/collections/:collection_id/fields
+server.tool(
+  "collection_fields_create_static",
+  {
+    collection_id: z.string(),
+    request: StaticFieldSchema
+  },
+  async ({ collection_id, request }) => {
+    const response = await client.collections.fields.create(collection_id, request);
+    return { content: [{ type: "text", text: JSON.stringify(response) }] };
+  }
+)
+
+// POST https://api.webflow.com/v2/collections/:collection_id/fields
+server.tool(
+  "collection_fields_create_option",
+  {
+    collection_id: z.string(),
+    request: OptionFieldSchema
+  },
+  async ({ collection_id, request }) => {
+    const response = await client.collections.fields.create(collection_id, request);
+    return { content: [{ type: "text", text: JSON.stringify(response) }] };
+  }
+)
+
+// POST https://api.webflow.com/v2/collections/:collection_id/fields
+server.tool(
+  "collection_fields_create_reference",
+  {
+    collection_id: z.string(),
+    request: ReferenceFieldSchema
+  },
+  async ({ collection_id, request }) => {
+    const response = await client.collections.fields.create(collection_id, request);
+    return { content: [{ type: "text", text: JSON.stringify(response) }] };
+  }
+)
+
+// request: Webflow.collections.FieldUpdate
+export const WebflowCollectionsFieldUpdateSchema = z.object({
+  isRequired: z.boolean().optional(),
+  displayName: z.string().optional(),
+  helpText: z.string().optional()
+})
+
+// PATCH https://api.webflow.com/v2/collections/:collection_id/fields/:field_id
+server.tool(
+  "collection_fields_update",
+  {
+    collection_id: z.string(),
+    field_id: z.string(),
+    request: WebflowCollectionsFieldUpdateSchema
+  },
+  async ({ collection_id, field_id, request }) => {
+    const response = await client.collections.fields.update(collection_id, field_id, request);
+    return { content: [{ type: "text", text: JSON.stringify(response) }] };
+  }
+)
+
 // request: Webflow.collections.ItemsCreateItemLiveRequest
 const WebflowCollectionsItemsCreateItemLiveRequestSchema = z.object({
   items: z


### PR DESCRIPTION
Add feature requests:
```
collections - create; // Create a collection
collection - fields - create - static; // Create a static field
collection - fields - create - option; // Create an option field
collection - fields - create - reference; // Create a reference field
collection - fields - update; // Update a custom field
```

I split field creation into 3 separate tools due to an unresolved bug in how Cursor MCP specifically handles zod unions types, causing the requests to fail. This is the same issue as in #11 