### PR TITLE
feat: proof of concept for Fern AI Chat tool

### DIFF
--- a/src/aiChat.ts
+++ b/src/aiChat.ts
@@ -1,0 +1,36 @@
+const BASE_URL = "https://webflow-ai.docs.buildwithfern.com/";
+
+export async function postChat(message: string) {
+  const response = await fetch(`${BASE_URL}/api/fern-docs/search/v2/chat`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: message }],
+      url: "https://buildwithfern.com/learn",
+      filters: [],
+    }),
+  });
+
+  const result = await streamToString(response);
+  return result;
+}
+
+async function streamToString(response: Response) {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("!reader");
+  }
+
+  let result = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    // Convert the Uint8Array to a string and append
+    result += new TextDecoder().decode(value);
+  }
+
+  return result;
+}

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -1,0 +1,11 @@
+export interface FeatureFlags {
+  enableWebflowAiChat: boolean;
+  // Add more feature flags here as needed
+}
+
+export function getFeatureFlags(env: NodeJS.ProcessEnv): FeatureFlags {
+  return {
+    enableWebflowAiChat: env.ENABLE_WEBFLOW_AI_CHAT === "true",
+    // Add more feature flag parsing here as needed
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createMcpServer, registerTools } from "./mcp";
 import { WebflowClient } from "webflow-api";
+import { getFeatureFlags } from "./featureFlags";
 
 // Verify WEBFLOW_TOKEN exists
 if (!process.env.WEBFLOW_TOKEN) {
@@ -19,10 +20,12 @@ function getClient() {
   return webflowClient;
 }
 
+const featureFlags = getFeatureFlags(process.env);
+
 // Configure and run local MCP server (stdio transport)
 async function run() {
-  const server = createMcpServer();
-  registerTools(server, getClient);
+  const server = createMcpServer(featureFlags);
+  registerTools(server, getClient, featureFlags);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/index.worker.ts
+++ b/src/index.worker.ts
@@ -2,6 +2,9 @@ import { McpAgent } from "agents/mcp";
 import { createMcpServer, registerTools } from "./mcp";
 import { WebflowClient } from "webflow-api";
 import { BearerAuthProvider } from "./bearerAuthProvider";
+import { getFeatureFlags } from "./featureFlags";
+
+const featureFlags = getFeatureFlags(process.env);
 
 type Props = Record<string, unknown> & {
   accessToken?: string;
@@ -9,7 +12,7 @@ type Props = Record<string, unknown> & {
 
 // Configure remote MCP server (SSE transport) for use in a Cloudflare Worker
 export class WebflowMcp extends McpAgent<Env, unknown, Props> {
-  server = createMcpServer();
+  server = createMcpServer(featureFlags);
 
   async init() {
     // Verify this.props.accessToken exists
@@ -27,7 +30,7 @@ export class WebflowMcp extends McpAgent<Env, unknown, Props> {
       return webflowClient;
     }
 
-    registerTools(this.server, getClient);
+    registerTools(this.server, getClient, featureFlags);
   }
 }
 


### PR DESCRIPTION
I've been dogfooding this myself and it's pretty cool 👀 Gives up-to-date information to the agent straight from your docs.

To enable this feature, simply build the server:
```shell
npm install
npm run build
```

Then add "ENABLE_WEBFLOW_AI_CHAT" feature flag to your env config:

```json
{
  "mcpServers": {
    "webflow": {
      "command": "node",
      "args": [
        "/path/to/webflow/mcp-server/dist/index.js"
      ],
      "env": {
        "WEBFLOW_TOKEN": "...",
        "ENABLE_WEBFLOW_AI_CHAT": "true"
      }
    }
  }
}
```

<img width="1920" alt="Screenshot 2025-04-17 at 3 58 13 PM" src="https://github.com/user-attachments/assets/008731b2-b7f6-4f7d-8c0e-111b38b0ebd5" />
