### PR TITLE
Update README.md Fix: mcp-remote sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A Node.js server implementing Model Context Protocol (MCP) for Webflow using the
 {
   "mcpServers": {
     "webflow": {
-      "command": "npx mcp-remote https://mcp.webflow.com/sse"
+      "command": "npx",
+      "args" : ["mcp-remote","https://mcp.webflow.com/sse"]
     }
   }
 }


### PR DESCRIPTION
fix: the command is just npx. then passed the rest as arguments. this can be seen in mcp-remote's example on their npm at https://www.npmjs.com/package/mcp-remote