### PR TITLE
fix: make name/slug on fieldData for a collection item update action optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "agents": "^0.0.59",
-        "webflow-api": "^3.1.1",
+        "webflow-api": "3.1.1",
         "zod": "^3.24.2"
       },
       "bin": {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -641,8 +641,8 @@ export function registerTools(
     isDraft: z.boolean().optional().describe("Indicates if the item is a draft."),
     fieldData: z.record(z.any()).and(
       z.object({
-        name: z.string().describe("Name of the field."),
-        slug: z.string().describe("URL structure of the Item in your site. Note: Updates to an item slug will break all links referencing the old slug."),
+        name: z.string().optional().describe("Name of the field."),
+        slug: z.string().optional().describe("URL structure of the Item in your site. Note: Updates to an item slug will break all links referencing the old slug."),
       })
     ),
   }).describe("Collection item update request schema.");


### PR DESCRIPTION
Name and slug in `fieldData` are optional on item update. This type mismatch was only on the non-live update call.