### PR TITLE
Add strict validation to enforce single action per request across all tool schemas

### DIFF
--- a/src/tools/cms.ts
+++ b/src/tools/cms.ts
@@ -478,10 +478,10 @@ export function registerCmsTools(
                   d.update_collection_items,
                   d.publish_collection_items,
                   d.delete_collection_items,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of get_collection_list, get_collection_details, create_collection, create_collection_static_field, create_collection_option_field, create_collection_reference_field, update_collection_field, list_collection_items, create_collection_items, update_collection_items, publish_collection_items, delete_collection_items.",
+                  "Provide at least one of get_collection_list, get_collection_details, create_collection, create_collection_static_field, create_collection_option_field, create_collection_reference_field, update_collection_field, list_collection_items, create_collection_items, update_collection_items, publish_collection_items, delete_collection_items.",
               }
             )
         ),

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -260,10 +260,10 @@ export function registerCommentsTools(
                     d.list_comment_threads,
                     d.get_comment_thread,
                     d.list_comment_replies,
-                  ].filter(Boolean).length === 1,
+                  ].filter(Boolean).length >= 1,
                 {
                   message:
-                    "Provide exactly one of list_comment_threads, get_comment_thread, list_comment_replies.",
+                    "Provide at least one of list_comment_threads, get_comment_thread, list_comment_replies.",
                 }
               )
           )

--- a/src/tools/components.ts
+++ b/src/tools/components.ts
@@ -260,10 +260,10 @@ export function registerComponentsTools(
                   d.update_component_content,
                   d.get_component_properties,
                   d.update_component_properties,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of list_components, get_component_content, update_component_content, get_component_properties, update_component_properties.",
+                  "Provide at least one of list_components, get_component_content, update_component_content, get_component_properties, update_component_properties.",
               }
             )
         ),

--- a/src/tools/deAsset.ts
+++ b/src/tools/deAsset.ts
@@ -97,10 +97,10 @@ export function registerDEAssetTools(server: McpServer, rpc: RPCType) {
                   d.create_folder,
                   d.get_all_assets_and_folders,
                   d.update_asset,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of create_folder, get_all_assets_and_folders, update_asset.",
+                  "Provide at least one of create_folder, get_all_assets_and_folders, update_asset.",
               }
             )
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -95,10 +95,10 @@ export function registerDEComponentsTools(server: McpServer, rpc: RPCType) {
                   d.close_component_view,
                   d.get_all_components,
                   d.rename_component,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, rename_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, rename_component.",
               }
             )
         ),

--- a/src/tools/deElement.ts
+++ b/src/tools/deElement.ts
@@ -262,10 +262,10 @@ export const registerDEElementTools = (server: McpServer, rpc: RPCType) => {
                   d.set_link,
                   d.set_heading_level,
                   d.set_image_asset,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of get_all_elements, get_selected_element, select_element, add_or_update_attribute, remove_attribute, update_id_attribute, set_text, set_style, set_link, set_heading_level, set_image_asset.",
+                  "Provide at least one of get_all_elements, get_selected_element, select_element, add_or_update_attribute, remove_attribute, update_id_attribute, set_text, set_style, set_link, set_heading_level, set_image_asset.",
               }
             )
         ),

--- a/src/tools/dePages.ts
+++ b/src/tools/dePages.ts
@@ -84,10 +84,10 @@ export function registerDEPagesTools(server: McpServer, rpc: RPCType) {
                   d.create_page_folder,
                   d.get_current_page,
                   d.switch_page,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of create_page, create_page_folder, get_current_page, switch_page.",
+                  "Provide at least one of create_page, create_page_folder, get_current_page, switch_page.",
               }
             )
         ),

--- a/src/tools/deStyle.ts
+++ b/src/tools/deStyle.ts
@@ -154,10 +154,10 @@ export function registerDEStyleTools(server: McpServer, rpc: RPCType) {
             .refine(
               (d) =>
                 [d.create_style, d.get_styles, d.update_style].filter(Boolean)
-                  .length === 1,
+                  .length >= 1,
               {
                 message:
-                  "Provide exactly one of create_style, get_styles, update_style.",
+                  "Provide at least one of create_style, get_styles, update_style.",
               }
             )
         ),

--- a/src/tools/deVariable.ts
+++ b/src/tools/deVariable.ts
@@ -228,10 +228,10 @@ export function registerDEVariableTools(server: McpServer, rpc: RPCType) {
                   d.update_number_variable,
                   d.update_percentage_variable,
                   d.update_font_family_variable,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of create_variable_collection, create_variable_mode, get_variable_collections, get_variables, create_color_variable, create_size_variable, create_number_variable, create_percentage_variable, create_font_family_variable, update_color_variable, update_size_variable, update_number_variable, update_percentage_variable, update_font_family_variable.",
+                  "Provide at least one of create_variable_collection, create_variable_mode, get_variable_collections, get_variables, create_color_variable, create_size_variable, create_number_variable, create_percentage_variable, create_font_family_variable, update_color_variable, update_size_variable, update_number_variable, update_percentage_variable, update_font_family_variable.",
               }
             )
         ),

--- a/src/tools/enterprise.ts
+++ b/src/tools/enterprise.ts
@@ -436,10 +436,10 @@ export function registerEnterpriseTools(
                     d.delete_robots_txt,
                     d.add_well_known_file,
                     d.remove_well_known_files,
-                  ].filter(Boolean).length === 1,
+                  ].filter(Boolean).length >= 1,
                 {
                   message:
-                    "Provide exactly one of list_301_redirects, create_301_redirect, update_301_redirect, delete_301_redirect, get_robots_txt, update_robots_txt, replace_robots_txt, delete_robots_txt, add_well_known_file, remove_well_known_files.",
+                    "Provide at least one of list_301_redirects, create_301_redirect, update_301_redirect, delete_301_redirect, get_robots_txt, update_robots_txt, replace_robots_txt, delete_robots_txt, add_well_known_file, remove_well_known_files.",
                 }
               )
           )

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -118,110 +118,134 @@ export function registerPagesTools(
         "Data tool - Pages tool to perform actions like list pages, get page metadata, update page settings, get page content, and update static content",
       inputSchema: {
         actions: z.array(
-          z.object({
-            // GET https://api.webflow.com/v2/sites/:site_id/pages
-            list_pages: z
-              .object({
-                site_id: z
-                  .string()
-                  .describe("The site's unique ID, used to list its pages."),
-                localeId: z
-                  .string()
-                  .optional()
-                  .describe(
-                    "Unique identifier for a specific locale. Applicable when using localization."
-                  ),
-                limit: z
-                  .number()
-                  .optional()
-                  .describe(
-                    "Maximum number of records to be returned (max limit: 100)"
-                  ),
-                offset: z
-                  .number()
-                  .optional()
-                  .describe(
-                    "Offset used for pagination if the results have more than limit records."
-                  ),
-              })
-              .optional()
-              .describe(
-                "List all pages within a site. Returns page metadata including IDs, titles, and slugs."
-              ),
-            // GET https://api.webflow.com/v2/pages/:page_id
-            get_page_metadata: z
-              .object({
-                page_id: z.string().describe("Unique identifier for the page."),
-                localeId: z
-                  .string()
-                  .optional()
-                  .describe(
-                    "Unique identifier for a specific locale. Applicable when using localization."
-                  ),
-              })
-              .optional()
-              .describe(
-                "Get metadata for a specific page including SEO settings, Open Graph data, and page status (draft/published)."
-              ),
-            // PUT https://api.webflow.com/v2/pages/:page_id
-            update_page_settings: z
-              .object({
-                page_id: z.string().describe("Unique identifier for the page."),
-                localeId: z
-                  .string()
-                  .optional()
-                  .describe(
-                    "Unique identifier for a specific locale. Applicable when using localization."
-                  ),
-                body: WebflowPageSchema,
-              })
-              .optional()
-              .describe(
-                "Update page settings including SEO metadata, Open Graph data, slug, and publishing status."
-              ),
-            // GET https://api.webflow.com/v2/pages/:page_id/dom
-            get_page_content: z
-              .object({
-                page_id: z.string().describe("Unique identifier for the page."),
-                localeId: z
-                  .string()
-                  .optional()
-                  .describe(
-                    "Unique identifier for a specific locale. Applicable when using localization."
-                  ),
-                limit: z
-                  .number()
-                  .optional()
-                  .describe(
-                    "Maximum number of records to be returned (max limit: 100)"
-                  ),
-                offset: z
-                  .number()
-                  .optional()
-                  .describe(
-                    "Offset used for pagination if the results have more than limit records."
-                  ),
-              })
-              .optional()
-              .describe(
-                "Get the content structure and data for a specific page including all elements and their properties for localization."
-              ),
-            // POST https://api.webflow.com/v2/pages/:page_id/dom
-            update_static_content: z
-              .object({
-                page_id: z.string().describe("Unique identifier for the page."),
-                localeId: z
-                  .string()
-                  .describe(
-                    "Unique identifier for a specific locale. Applicable when using localization."
-                  ),
-                nodes: WebflowPageDomWriteNodesItemSchema,
-              })
-              .optional()
-              .describe(
-                "Update content on a static page in secondary locales by modifying text nodes and property overrides."
-              ),
-          })
+          z
+            .object({
+              // GET https://api.webflow.com/v2/sites/:site_id/pages
+              list_pages: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("The site's unique ID, used to list its pages."),
+                  localeId: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Unique identifier for a specific locale. Applicable when using localization."
+                    ),
+                  limit: z
+                    .number()
+                    .optional()
+                    .describe(
+                      "Maximum number of records to be returned (max limit: 100)"
+                    ),
+                  offset: z
+                    .number()
+                    .optional()
+                    .describe(
+                      "Offset used for pagination if the results have more than limit records."
+                    ),
+                })
+                .optional()
+                .describe(
+                  "List all pages within a site. Returns page metadata including IDs, titles, and slugs."
+                ),
+              // GET https://api.webflow.com/v2/pages/:page_id
+              get_page_metadata: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("Unique identifier for the page."),
+                  localeId: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Unique identifier for a specific locale. Applicable when using localization."
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get metadata for a specific page including SEO settings, Open Graph data, and page status (draft/published)."
+                ),
+              // PUT https://api.webflow.com/v2/pages/:page_id
+              update_page_settings: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("Unique identifier for the page."),
+                  localeId: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Unique identifier for a specific locale. Applicable when using localization."
+                    ),
+                  body: WebflowPageSchema,
+                })
+                .optional()
+                .describe(
+                  "Update page settings including SEO metadata, Open Graph data, slug, and publishing status."
+                ),
+              // GET https://api.webflow.com/v2/pages/:page_id/dom
+              get_page_content: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("Unique identifier for the page."),
+                  localeId: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Unique identifier for a specific locale. Applicable when using localization."
+                    ),
+                  limit: z
+                    .number()
+                    .optional()
+                    .describe(
+                      "Maximum number of records to be returned (max limit: 100)"
+                    ),
+                  offset: z
+                    .number()
+                    .optional()
+                    .describe(
+                      "Offset used for pagination if the results have more than limit records."
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get the content structure and data for a specific page including all elements and their properties for localization."
+                ),
+              // POST https://api.webflow.com/v2/pages/:page_id/dom
+              update_static_content: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("Unique identifier for the page."),
+                  localeId: z
+                    .string()
+                    .describe(
+                      "Unique identifier for a specific locale. Applicable when using localization."
+                    ),
+                  nodes: WebflowPageDomWriteNodesItemSchema,
+                })
+                .optional()
+                .describe(
+                  "Update content on a static page in secondary locales by modifying text nodes and property overrides."
+                ),
+            })
+            .strict()
+            .refine(
+              (d) =>
+                [
+                  d.list_pages,
+                  d.get_page_metadata,
+                  d.update_page_settings,
+                  d.get_page_content,
+                  d.update_static_content,
+                ].filter(Boolean).length >= 1,
+              {
+                message:
+                  "Provide at least one of list_pages, get_page_metadata, update_page_settings, get_page_content, update_static_content.",
+              }
+            )
         ),
       },
     },

--- a/src/tools/scripts.ts
+++ b/src/tools/scripts.ts
@@ -271,10 +271,10 @@ export function registerScriptsTools(
                   d.get_page_script,
                   d.upsert_page_script,
                   d.delete_all_page_scripts,
-                ].filter(Boolean).length === 1,
+                ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide exactly one of list_registered_scripts, list_applied_scripts, add_inline_site_script, delete_all_site_scripts, get_page_script, upsert_page_script, delete_all_page_scripts.",
+                  "Provide at least one of list_registered_scripts, list_applied_scripts, add_inline_site_script, delete_all_site_scripts, get_page_script, upsert_page_script, delete_all_page_scripts.",
               }
             )
         ),

--- a/src/tools/sites.ts
+++ b/src/tools/sites.ts
@@ -97,10 +97,10 @@ export function registerSiteTools(
             .refine(
               (d) =>
                 [d.list_sites, d.get_site, d.publish_site].filter(Boolean)
-                  .length === 1,
+                  .length >= 1,
               {
                 message:
-                  "Provide exactly one of list_sites, get_site, publish_site.",
+                  "Provide at least one of list_sites, get_site, publish_site.",
               }
             )
         ),


### PR DESCRIPTION
- Added `.strict()` to Zod action schemas across all 13 tool files to reject unrecognized keys, preventing typos or invalid fields from being silently ignored
- Added `.refine()` validation to ensure each action entry contains at least one valid action, providing a clear error message when an empty object is passed
