### PR TITLE
IDSC-1440: Add site activity logs support to enterprise tool

### DIFF
--- a/src/tools/enterprise.ts
+++ b/src/tools/enterprise.ts
@@ -8,16 +8,16 @@ import {
   formatErrorResponse,
   textContent,
   toolResponse,
-} from "../utils/formatResponse";
+} from "../utils";
 
 export function registerEnterpriseTools(
   server: McpServer,
-  getClient: () => WebflowClient
+  getClient: () => WebflowClient,
 ) {
   const list301Redirects = async (arg: { site_id: string }) => {
     const response = await getClient().sites.redirects.list(
       arg.site_id,
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -32,7 +32,7 @@ export function registerEnterpriseTools(
         fromUrl: arg.fromUrl,
         toUrl: arg.toUrl,
       },
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -49,7 +49,7 @@ export function registerEnterpriseTools(
         fromUrl: arg.fromUrl,
         toUrl: arg.toUrl,
       },
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -60,14 +60,14 @@ export function registerEnterpriseTools(
     const response = await getClient().sites.redirects.delete(
       arg.site_id,
       arg.redirect_id,
-      requestOptions
+      requestOptions,
     );
     return response;
   };
   const getRobotsDotTxt = async (arg: { site_id: string }) => {
     const response = await getClient().sites.robotsTxt.get(
       arg.site_id,
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -90,7 +90,7 @@ export function registerEnterpriseTools(
     const response = await getClient().sites.robotsTxt.patch(
       arg.site_id,
       data,
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -113,7 +113,7 @@ export function registerEnterpriseTools(
     const response = await getClient().sites.robotsTxt.put(
       arg.site_id,
       data,
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -136,7 +136,7 @@ export function registerEnterpriseTools(
     const response = await getClient().sites.robotsTxt.patch(
       arg.site_id,
       data,
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -154,7 +154,7 @@ export function registerEnterpriseTools(
         fileName: arg.fileName,
         contentType: arg.contentType,
       },
-      requestOptions
+      requestOptions,
     );
     return response;
   };
@@ -168,7 +168,20 @@ export function registerEnterpriseTools(
       {
         fileNames: arg.fileNames,
       },
-      requestOptions
+      requestOptions,
+    );
+    return response;
+  };
+
+  const listSiteActivityLogs = async (arg: {
+    site_id: string;
+    limit?: number;
+    offset?: number;
+  }) => {
+    const response = await getClient().sites.activityLogs.list(
+      arg.site_id,
+      { limit: arg.limit, offset: arg.offset },
+      requestOptions,
     );
     return response;
   };
@@ -192,7 +205,7 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to list its 301 redirects."
+                        "The site's unique ID, used to list its 301 redirects.",
                       ),
                   })
                   .optional()
@@ -202,17 +215,17 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to create a 301 redirect."
+                        "The site's unique ID, used to create a 301 redirect.",
                       ),
                     fromUrl: z
                       .string()
                       .describe(
-                        "The source URL path that will be redirected (e.g., '/old-page')."
+                        "The source URL path that will be redirected (e.g., '/old-page').",
                       ),
                     toUrl: z
                       .string()
                       .describe(
-                        "The destination URL path where requests will be redirected to (e.g., '/new-page')."
+                        "The destination URL path where requests will be redirected to (e.g., '/new-page').",
                       ),
                   })
                   .optional()
@@ -222,22 +235,22 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to update a 301 redirect."
+                        "The site's unique ID, used to update a 301 redirect.",
                       ),
                     redirect_id: z
                       .string()
                       .describe(
-                        "The redirect's unique ID, used to identify which redirect to update."
+                        "The redirect's unique ID, used to identify which redirect to update.",
                       ),
                     fromUrl: z
                       .string()
                       .describe(
-                        "The source URL path that will be redirected (e.g., '/old-page')."
+                        "The source URL path that will be redirected (e.g., '/old-page').",
                       ),
                     toUrl: z
                       .string()
                       .describe(
-                        "The destination URL path where requests will be redirected to (e.g., '/new-page')."
+                        "The destination URL path where requests will be redirected to (e.g., '/new-page').",
                       ),
                   })
                   .optional()
@@ -247,12 +260,12 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to delete a 301 redirect."
+                        "The site's unique ID, used to delete a 301 redirect.",
                       ),
                     redirect_id: z
                       .string()
                       .describe(
-                        "The redirect's unique ID, used to identify which redirect to delete."
+                        "The redirect's unique ID, used to identify which redirect to delete.",
                       ),
                   })
                   .optional()
@@ -262,7 +275,7 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to get its robots.txt configuration."
+                        "The site's unique ID, used to get its robots.txt configuration.",
                       ),
                   })
                   .optional()
@@ -272,7 +285,7 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to update its robots.txt."
+                        "The site's unique ID, used to update its robots.txt.",
                       ),
                     rules: z
                       .array(
@@ -280,7 +293,7 @@ export function registerEnterpriseTools(
                           userAgent: z
                             .string()
                             .describe(
-                              "The user agent to apply rules to (e.g., '*', 'Googlebot')."
+                              "The user agent to apply rules to (e.g., '*', 'Googlebot').",
                             ),
                           allow: z
                             .array(z.string())
@@ -288,29 +301,29 @@ export function registerEnterpriseTools(
                           disallow: z
                             .array(z.string())
                             .describe("Array of URL paths to disallow."),
-                        })
+                        }),
                       )
                       .optional()
                       .describe(
-                        "Array of rules to apply to the robots.txt file."
+                        "Array of rules to apply to the robots.txt file.",
                       ),
                     sitemap: z
                       .string()
                       .optional()
                       .describe(
-                        "URL to the sitemap (e.g., 'https://example.com/sitemap.xml')."
+                        "URL to the sitemap (e.g., 'https://example.com/sitemap.xml').",
                       ),
                   })
                   .optional()
                   .describe(
-                    "Partially update the robots.txt file (PATCH operation)."
+                    "Partially update the robots.txt file (PATCH operation).",
                   ),
                 replace_robots_txt: z
                   .object({
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to replace its robots.txt."
+                        "The site's unique ID, used to replace its robots.txt.",
                       ),
                     rules: z
                       .array(
@@ -318,7 +331,7 @@ export function registerEnterpriseTools(
                           userAgent: z
                             .string()
                             .describe(
-                              "The user agent to apply rules to (e.g., '*', 'Googlebot')."
+                              "The user agent to apply rules to (e.g., '*', 'Googlebot').",
                             ),
                           allow: z
                             .array(z.string())
@@ -326,29 +339,29 @@ export function registerEnterpriseTools(
                           disallow: z
                             .array(z.string())
                             .describe("Array of URL paths to disallow."),
-                        })
+                        }),
                       )
                       .optional()
                       .describe(
-                        "Array of rules to apply to the robots.txt file."
+                        "Array of rules to apply to the robots.txt file.",
                       ),
                     sitemap: z
                       .string()
                       .optional()
                       .describe(
-                        "URL to the sitemap (e.g., 'https://example.com/sitemap.xml')."
+                        "URL to the sitemap (e.g., 'https://example.com/sitemap.xml').",
                       ),
                   })
                   .optional()
                   .describe(
-                    "Completely replace the robots.txt file (PUT operation)."
+                    "Completely replace the robots.txt file (PUT operation).",
                   ),
                 delete_robots_txt: z
                   .object({
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to delete rules from its robots.txt."
+                        "The site's unique ID, used to delete rules from its robots.txt.",
                       ),
                     rules: z
                       .array(
@@ -356,7 +369,7 @@ export function registerEnterpriseTools(
                           userAgent: z
                             .string()
                             .describe(
-                              "The user agent to apply rules to (e.g., '*', 'Googlebot')."
+                              "The user agent to apply rules to (e.g., '*', 'Googlebot').",
                             ),
                           allow: z
                             .array(z.string())
@@ -364,11 +377,11 @@ export function registerEnterpriseTools(
                           disallow: z
                             .array(z.string())
                             .describe("Array of URL paths to disallow."),
-                        })
+                        }),
                       )
                       .optional()
                       .describe(
-                        "Array of rules to remove from the robots.txt file."
+                        "Array of rules to remove from the robots.txt file.",
                       ),
                     sitemap: z
                       .string()
@@ -382,44 +395,68 @@ export function registerEnterpriseTools(
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to add a well-known file."
+                        "The site's unique ID, used to add a well-known file.",
                       ),
                     fileName: z
                       .string()
                       .describe(
-                        `The name of the well-known file (e.g., 'apple-app-site-association', 'assetlinks.json'). ".noext" is a special file extension that removes other extensions. For example, apple-app-site-association.noext.txt will be uploaded as apple-app-site-association. Use this extension for tools that have trouble uploading extensionless files.`
+                        `The name of the well-known file (e.g., 'apple-app-site-association', 'assetlinks.json'). ".noext" is a special file extension that removes other extensions. For example, apple-app-site-association.noext.txt will be uploaded as apple-app-site-association. Use this extension for tools that have trouble uploading extensionless files.`,
                       ),
                     fileData: z
                       .string()
                       .describe(
-                        "The content/data of the well-known file as a string."
+                        "The content/data of the well-known file as a string.",
                       ),
                     contentType: z
                       .enum(["application/json", "text/plain"])
                       .describe(
-                        "The MIME type of the file content (application/json or text/plain)."
+                        "The MIME type of the file content (application/json or text/plain).",
                       ),
                   })
                   .optional()
                   .describe(
-                    "Add or update a well-known file to the site's /.well-known/ directory."
+                    "Add or update a well-known file to the site's /.well-known/ directory.",
                   ),
                 remove_well_known_files: z
                   .object({
                     site_id: z
                       .string()
                       .describe(
-                        "The site's unique ID, used to remove well-known files."
+                        "The site's unique ID, used to remove well-known files.",
                       ),
                     fileNames: z
                       .array(z.string())
                       .describe(
-                        "Array of file names to remove from the /.well-known/ directory."
+                        "Array of file names to remove from the /.well-known/ directory.",
                       ),
                   })
                   .optional()
                   .describe(
-                    "Remove one or more well-known files from the site."
+                    "Remove one or more well-known files from the site.",
+                  ),
+                list_site_activity_logs: z
+                  .object({
+                    site_id: z
+                      .string()
+                      .describe(
+                        "The site's unique ID, used to list its activity log events.",
+                      ),
+                    limit: z
+                      .number()
+                      .optional()
+                      .describe(
+                        "Maximum number of records to return (max 100).",
+                      ),
+                    offset: z
+                      .number()
+                      .optional()
+                      .describe(
+                        "Offset used for pagination if the results have more than limit records.",
+                      ),
+                  })
+                  .optional()
+                  .describe(
+                    "List activity log events for a site. Requires Enterprise hosting plan. To get logs for multiple sites, include multiple actions in the array — each is handled independently so a failure for one site won't prevent results from others.",
                   ),
               })
               .strict()
@@ -436,21 +473,27 @@ export function registerEnterpriseTools(
                     d.delete_robots_txt,
                     d.add_well_known_file,
                     d.remove_well_known_files,
+                    d.list_site_activity_logs,
                   ].filter(Boolean).length >= 1,
                 {
                   message:
-                    "Provide at least one of list_301_redirects, create_301_redirect, update_301_redirect, delete_301_redirect, get_robots_txt, update_robots_txt, replace_robots_txt, delete_robots_txt, add_well_known_file, remove_well_known_files.",
-                }
-              )
+                    "Provide at least one of list_301_redirects, create_301_redirect, update_301_redirect, delete_301_redirect, get_robots_txt, update_robots_txt, replace_robots_txt, delete_robots_txt, add_well_known_file, remove_well_known_files, list_site_activity_logs.",
+                },
+              ),
           )
           .min(1)
           .describe("The actions to perform on the enterprise tool."),
       },
     },
     async ({ actions }) => {
+      // Per-action try/catch (unlike other tools which use an outer try/catch)
+      // because a workspace can contain a mix of Enterprise and non-Enterprise
+      // sites. A 403 from a non-Enterprise site should not prevent results from
+      // Enterprise sites in the same batch.
       const result: Content[] = [];
-      try {
-        for (const action of actions) {
+      let hasError = false;
+      for (const action of actions) {
+        try {
           if (action.list_301_redirects) {
             const content = await list301Redirects(action.list_301_redirects);
             result.push(textContent(content));
@@ -477,7 +520,7 @@ export function registerEnterpriseTools(
           }
           if (action.replace_robots_txt) {
             const content = await replaceRobotsDotTxt(
-              action.replace_robots_txt
+              action.replace_robots_txt,
             );
             result.push(textContent(content));
           }
@@ -491,15 +534,40 @@ export function registerEnterpriseTools(
           }
           if (action.remove_well_known_files) {
             const content = await removeWellKnownFiles(
-              action.remove_well_known_files
+              action.remove_well_known_files,
             );
             result.push(textContent(content));
           }
+          if (action.list_site_activity_logs) {
+            const content = await listSiteActivityLogs(
+              action.list_site_activity_logs,
+            );
+            result.push(textContent(content));
+          }
+        } catch (error) {
+          hasError = true;
+          const err = error as {
+            statusCode?: number;
+            body?: { code?: string };
+          };
+          if (
+            err.statusCode === 403 &&
+            (err.body?.code === "not_enterprise_plan_site" ||
+              err.body?.code === "not_enterprise_plan_workspace")
+          ) {
+            result.push(
+              textContent({
+                error: true,
+                message:
+                  "This site does not have an Enterprise hosting plan. This action requires an Enterprise site plan.",
+              }),
+            );
+          } else {
+            result.push(...formatErrorResponse(error).content);
+          }
         }
-        return toolResponse(result);
-      } catch (error) {
-        return formatErrorResponse(error);
       }
-    }
+      return { ...toolResponse(result), isError: hasError };
+    },
   );
 }


### PR DESCRIPTION
## Summary
* Add `list_site_activity_logs` action to `data_enterprise_tool` for retrieving site activity logs (`GET /v2/sites/{site_id}/activity_logs`)
* Implement per-action error handling so non-Enterprise site failures don't block results from Enterprise sites in the same batch
* Pin `zod` to `3.25.76` to fix `zod/v3` subpath runtime resolution required by `@modelcontextprotocol/sdk@1.25.2`

## Details
Activity logs are an Enterprise-only Webflow API. Workspaces commonly contain a mix of Enterprise and non-Enterprise sites. When an LLM requests logs for multiple sites in one batch, non-Enterprise sites return a 403 with `body.code: "not_enterprise_plan_site"`. Without per-action error handling, the first 403 would abort the entire batch.

### Changes in `src/tools/enterprise.ts`
* New `listSiteActivityLogs` helper calling `getClient().sites.activityLogs.list()`
* New `list_site_activity_logs` schema with `site_id`, optional `limit`, optional `offset`
* Per-action try/catch (documented with comment explaining the deviation from other tools)
* 403 detection using Webflow SDK's `WebflowError.statusCode` and `body.code`
* Generic errors delegated to existing `formatErrorResponse` utility
* MCP `isError` flag set when any action fails

### Changes in `package.json`
* `zod` pinned to `3.25.76` (was `^3.24.2`) — required for `zod/v3` subpath to resolve at runtime

## Testing performed
1. **Build** — `npx tsup src/index.ts` succeeds
2. **Runtime** — `zod/v3` resolves correctly with `zod@3.25.76`
3. **Mixed workspace** — Tested against workspace with 10 sites (2 Enterprise, 8 non-Enterprise):
   
   * Enterprise sites returned activity log data (e.g., `backup_created` events)
   * Non-Enterprise sites returned `{"error":true,"message":"This site does not have an Enterprise hosting plan. This action requires an Enterprise site plan."}`
   * Enterprise results were not blocked by non-Enterprise failures
4. **MCP protocol** — Confirmed `isError: true` set on response when any action fails
5. **Error shape verification** — Confirmed Webflow API returns `statusCode: 403` with `body.code: "not_enterprise_plan_site"` (not `not_enterprise_plan_workspace`)
6. **Code review** — Two rounds of 4-dimensional review (security, architecture, readability, simplicity), all blockers resolved

