### PR TITLE
feat(ai): add list-workflows public MCP tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,17 @@ function getClient() {
   return webflowClient;
 }
 
+// Return the Webflow token for direct API calls
+function getToken() {
+  return process.env.WEBFLOW_TOKEN!;
+}
+
 // Configure and run local MCP server (stdio transport)
 async function run() {
   const server = createMcpServer();
   const { callTool } = await initDesignerAppBridge();
   registerMiscTools(server);
-  registerTools(server, getClient);
+  registerTools(server, getClient, getToken);
   registerDesignerTools(server, {
     callTool,
     getClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,17 +26,12 @@ function getClient() {
   return webflowClient;
 }
 
-// Return the Webflow token for direct API calls
-function getToken() {
-  return process.env.WEBFLOW_TOKEN!;
-}
-
 // Configure and run local MCP server (stdio transport)
 async function run() {
   const server = createMcpServer();
   const { callTool } = await initDesignerAppBridge();
   registerMiscTools(server);
-  registerTools(server, getClient, getToken);
+  registerTools(server, getClient);
   registerDesignerTools(server, {
     callTool,
     getClient,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -47,8 +47,7 @@ export const requestOptions = {
 // Register tools
 export function registerTools(
   server: McpServer,
-  getClient: () => WebflowClient,
-  getToken: () => string
+  getClient: () => WebflowClient
 ) {
   registerAiChatTools(server);
   registerCmsTools(server, getClient);
@@ -59,7 +58,13 @@ export function registerTools(
   registerCommentsTools(server, getClient);
   registerEnterpriseTools(server, getClient);
   registerWebhookTools(server, getClient);
-  registerWorkflowsTools(server, getToken);
+}
+
+export function registerWorkflowTools(
+  server: McpServer,
+  getAccessToken: () => string
+) {
+  registerWorkflowsTools(server, getAccessToken);
 }
 
 export function registerDesignerTools(server: McpServer, rpc: RPCType) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -18,6 +18,7 @@ import {
   registerCommentsTools,
   registerEnterpriseTools,
   registerWebhookTools,
+  registerWorkflowsTools,
 } from "./tools";
 import { RPCType } from "./types/RPCType";
 
@@ -46,7 +47,8 @@ export const requestOptions = {
 // Register tools
 export function registerTools(
   server: McpServer,
-  getClient: () => WebflowClient
+  getClient: () => WebflowClient,
+  getToken: () => string
 ) {
   registerAiChatTools(server);
   registerCmsTools(server, getClient);
@@ -57,6 +59,7 @@ export function registerTools(
   registerCommentsTools(server, getClient);
   registerEnterpriseTools(server, getClient);
   registerWebhookTools(server, getClient);
+  registerWorkflowsTools(server, getToken);
 }
 
 export function registerDesignerTools(server: McpServer, rpc: RPCType) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@ export { registerSiteTools } from "./sites";
 export { registerCommentsTools } from "./comments";
 export { registerEnterpriseTools } from "./enterprise";
 export { registerWebhookTools } from "./webhooks";
+export { registerWorkflowsTools } from "./workflows";
 // Designer API Tools
 export { registerDEAssetTools } from "./deAsset";
 export { registerDEComponentsTools } from "./deComponents";

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -1,0 +1,94 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v3";
+import { requestOptions } from "../mcp";
+import {
+  type Content,
+  formatErrorResponse,
+  textContent,
+  toolResponse,
+} from "../utils";
+
+const WEBFLOW_API_BASE = "https://api.webflow.com";
+
+async function listWorkflows(arg: {
+  site_id: string;
+  token: string;
+}): Promise<unknown> {
+  const response = await fetch(
+    `${WEBFLOW_API_BASE}/v2/sites/${arg.site_id}/workflows`,
+    {
+      headers: {
+        Authorization: `Bearer ${arg.token}`,
+        ...requestOptions.headers,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw Object.assign(new Error(`HTTP ${response.status}`), {
+      name: "WebflowApiError",
+      status: response.status,
+      ...error,
+    });
+  }
+
+  return response.json();
+}
+
+export function registerWorkflowsTools(
+  server: McpServer,
+  getToken: () => string
+) {
+  server.registerTool(
+    "data_workflows_tool",
+    {
+      title: "Data Workflows Tool",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      description:
+        "Data tool - Workflows tool to perform actions like listing AI workflows configured for a site.",
+      inputSchema: {
+        actions: z.array(
+          z
+            .object({
+              // GET https://api.webflow.com/v2/sites/:site_id/workflows
+              list_workflows: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                })
+                .optional()
+                .describe(
+                  "List all AI workflows configured for a site. Returns each workflow's ID, name, active status, and template slug."
+                ),
+            })
+            .strict()
+            .refine((d) => [d.list_workflows].filter(Boolean).length >= 1, {
+              message: "Provide at least one of list_workflows.",
+            })
+        ),
+      },
+    },
+    async ({ actions }) => {
+      const result: Content[] = [];
+      try {
+        for (const action of actions) {
+          if (action.list_workflows) {
+            const content = await listWorkflows({
+              site_id: action.list_workflows.site_id,
+              token: getToken(),
+            });
+            result.push(textContent(content));
+          }
+        }
+        return toolResponse(result);
+      } catch (error) {
+        return formatErrorResponse(error);
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

**PR 3 of 3** for DEVPL-3935 — exposes AI Workflows to the public Webflow MCP server.

Prerequisite: webflow/webflow#101267 (merged) added `GET /v2/sites/:site_id/workflows`. This PR wires up the public-facing tool that calls it.

- **`src/tools/workflows.ts`** — new `registerWorkflowsTools` function; registers `data_workflows_tool` with a `list_workflows` action that calls `GET /v2/sites/:site_id/workflows` via raw fetch (no SDK method exists yet for workflows)
- **`src/tools/index.ts`** — exports `registerWorkflowsTools`
- **`src/mcp.ts`** — adds `getToken` param to `registerTools`, calls `registerWorkflowsTools`
- **`src/index.ts`** — adds `getToken` helper, passes it to `registerTools`

The `getToken` threading is needed because workflows uses raw `fetch` instead of the `WebflowClient` SDK (same pattern as `aiChat.ts`).

## Test plan

- [x] Set `WEBFLOW_TOKEN` to a token for a site with `AI_WORKFLOWS` flag enabled
- [x] Run server locally: `npm run build && node dist/index.js`
- [x] Call `data_workflows_tool` with `list_workflows: { site_id: "<id>" }` → verify response shape `[{ workflowId, name, isActive, templateSlug }]`
- [x] Call with a site that doesn't have the flag → verify `403` is surfaced via `formatErrorResponse`
