### PR TITLE
feat(ai): add execute_workflow and get_workflow_execution_status to data_workflows_tool

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -59,7 +59,6 @@ export function registerTools(
   registerCommentsTools(server, getClient);
   registerEnterpriseTools(server, getClient);
   registerWebhookTools(server, getClient);
-  registerWorkflowsTools(server, getAccessToken);
 }
 
 export function registerWorkflowTools(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -59,6 +59,7 @@ export function registerTools(
   registerCommentsTools(server, getClient);
   registerEnterpriseTools(server, getClient);
   registerWebhookTools(server, getClient);
+  registerWorkflowsTools(server, getAccessToken);
 }
 
 export function registerWorkflowTools(

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -10,19 +10,18 @@ import {
 
 const WEBFLOW_API_BASE = "https://api.webflow.com";
 
-async function listWorkflows(arg: {
-  site_id: string;
-  token: string;
-}): Promise<unknown> {
-  const response = await fetch(
-    `${WEBFLOW_API_BASE}/v2/sites/${arg.site_id}/workflows`,
-    {
-      headers: {
-        Authorization: `Bearer ${arg.token}`,
-        ...requestOptions.headers,
-      },
-    }
-  );
+async function apiRequest(
+  method: string,
+  path: string,
+  token: string
+): Promise<unknown> {
+  const response = await fetch(`${WEBFLOW_API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...requestOptions.headers,
+    },
+  });
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));
@@ -45,11 +44,11 @@ export function registerWorkflowsTools(
     {
       title: "Data Workflows Tool",
       annotations: {
-        readOnlyHint: true,
+        readOnlyHint: false,
         openWorldHint: false,
       },
       description:
-        "Data tool - Workflows tool to perform actions like listing AI workflows configured for a site.",
+        "Data tool - Workflows tool to list AI workflows, execute a workflow, and poll execution status.",
       inputSchema: {
         actions: z.array(
           z
@@ -65,11 +64,50 @@ export function registerWorkflowsTools(
                 .describe(
                   "List all AI workflows configured for a site. Returns each workflow's ID, name, active status, and template slug."
                 ),
+              // POST https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/execute
+              execute_workflow: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  workflow_id: z
+                    .string()
+                    .describe("Unique identifier for the workflow to execute."),
+                })
+                .optional()
+                .describe(
+                  "Execute an AI workflow. The workflow must be active. Returns an execution_id to poll with get_workflow_execution_status."
+                ),
+              // GET https://api.webflow.com/v2/sites/:site_id/workflows/executions/:execution_id
+              get_workflow_execution_status: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  execution_id: z
+                    .string()
+                    .describe(
+                      "Execution ID returned by execute_workflow. Poll until isFinished is true."
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get the status of a workflow execution. Returns status, start/stop times, and isFinished."
+                ),
             })
             .strict()
-            .refine((d) => [d.list_workflows].filter(Boolean).length >= 1, {
-              message: "Provide at least one of list_workflows.",
-            })
+            .refine(
+              (d) =>
+                [
+                  d.list_workflows,
+                  d.execute_workflow,
+                  d.get_workflow_execution_status,
+                ].filter(Boolean).length >= 1,
+              {
+                message:
+                  "Provide at least one of list_workflows, execute_workflow, get_workflow_execution_status.",
+              }
+            )
         ),
       },
     },
@@ -78,10 +116,27 @@ export function registerWorkflowsTools(
       try {
         for (const action of actions) {
           if (action.list_workflows) {
-            const content = await listWorkflows({
-              site_id: action.list_workflows.site_id,
-              token: getToken(),
-            });
+            const content = await apiRequest(
+              "GET",
+              `/v2/sites/${action.list_workflows.site_id}/workflows`,
+              getToken()
+            );
+            result.push(textContent(content));
+          }
+          if (action.execute_workflow) {
+            const content = await apiRequest(
+              "POST",
+              `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
+              getToken()
+            );
+            result.push(textContent(content));
+          }
+          if (action.get_workflow_execution_status) {
+            const content = await apiRequest(
+              "GET",
+              `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
+              getToken()
+            );
             result.push(textContent(content));
           }
         }

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -35,6 +35,44 @@ async function apiRequest(
   return response.json();
 }
 
+async function handleWorkflowActions(
+  actions: Array<{
+    list_workflows?: { site_id: string };
+    execute_workflow?: { site_id: string; workflow_id: string };
+    get_workflow_execution_status?: { site_id: string; execution_id: string };
+  }>,
+  getToken: () => string
+): Promise<Content[]> {
+  const result: Content[] = [];
+  for (const action of actions) {
+    if (action.list_workflows) {
+      const content = await apiRequest(
+        "GET",
+        `/v2/sites/${action.list_workflows.site_id}/workflows`,
+        getToken()
+      );
+      result.push(textContent(content));
+    }
+    if (action.execute_workflow) {
+      const content = await apiRequest(
+        "POST",
+        `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
+        getToken()
+      );
+      result.push(textContent(content));
+    }
+    if (action.get_workflow_execution_status) {
+      const content = await apiRequest(
+        "GET",
+        `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
+        getToken()
+      );
+      result.push(textContent(content));
+    }
+  }
+  return result;
+}
+
 export function registerWorkflowsTools(
   server: McpServer,
   getToken: () => string
@@ -112,34 +150,8 @@ export function registerWorkflowsTools(
       },
     },
     async ({ actions }) => {
-      const result: Content[] = [];
       try {
-        for (const action of actions) {
-          if (action.list_workflows) {
-            const content = await apiRequest(
-              "GET",
-              `/v2/sites/${action.list_workflows.site_id}/workflows`,
-              getToken()
-            );
-            result.push(textContent(content));
-          }
-          if (action.execute_workflow) {
-            const content = await apiRequest(
-              "POST",
-              `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
-              getToken()
-            );
-            result.push(textContent(content));
-          }
-          if (action.get_workflow_execution_status) {
-            const content = await apiRequest(
-              "GET",
-              `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
-              getToken()
-            );
-            result.push(textContent(content));
-          }
-        }
+        const result = await handleWorkflowActions(actions, getToken);
         return toolResponse(result);
       } catch (error) {
         return formatErrorResponse(error);

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -13,8 +13,9 @@ const WEBFLOW_API_BASE = "https://api.webflow.com";
 async function apiRequest(
   method: string,
   path: string,
-  token: string
-): Promise<unknown> {
+  getToken: () => string
+): Promise<Content> {
+  const token = getToken();
   const response = await fetch(`${WEBFLOW_API_BASE}${path}`, {
     method,
     headers: {
@@ -32,7 +33,7 @@ async function apiRequest(
     });
   }
 
-  return response.json();
+  return textContent(await response.json());
 }
 
 async function handleWorkflowActions(
@@ -46,28 +47,31 @@ async function handleWorkflowActions(
   const result: Content[] = [];
   for (const action of actions) {
     if (action.list_workflows) {
-      const content = await apiRequest(
-        "GET",
-        `/v2/sites/${action.list_workflows.site_id}/workflows`,
-        getToken()
+      result.push(
+        await apiRequest(
+          "GET",
+          `/v2/sites/${action.list_workflows.site_id}/workflows`,
+          getToken
+        )
       );
-      result.push(textContent(content));
     }
     if (action.execute_workflow) {
-      const content = await apiRequest(
-        "POST",
-        `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
-        getToken()
+      result.push(
+        await apiRequest(
+          "POST",
+          `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
+          getToken
+        )
       );
-      result.push(textContent(content));
     }
     if (action.get_workflow_execution_status) {
-      const content = await apiRequest(
-        "GET",
-        `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
-        getToken()
+      result.push(
+        await apiRequest(
+          "GET",
+          `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
+          getToken
+        )
       );
-      result.push(textContent(content));
     }
   }
   return result;


### PR DESCRIPTION
JIRA: https://webflow.atlassian.net/browse/DEVPL-3947

## Summary

Extends `data_workflows_tool` with two new actions, completing the execute workflow capability:

- **`execute_workflow`** — `POST /v2/sites/:site_id/workflows/:workflow_id/execute` — triggers an AI workflow; returns `{ executionId, workflowId }`
- **`get_workflow_execution_status`** — `GET /v2/sites/:site_id/workflows/executions/:execution_id` — polls an execution; returns `{ executionId, status, startedAt, stoppedAt, isFinished }`
- Also refactors the per-action `fetch` calls into a shared `apiRequest` helper, and extracts the action dispatch loop into a `handleWorkflowActions` helper

**Depends on:** webflow/webflow#101439 (the OAuth v2 routes for execute + get-status)

### Agent workflow this enables

```
list_workflows → pick a workflow_id
execute_workflow → get execution_id
get_workflow_execution_status (poll) → wait for isFinished: true
```

## Test plan

- [ ] Set `WEBFLOW_TOKEN` for a site with `AI_WORKFLOWS` flag enabled
- [ ] Call `data_workflows_tool` with `execute_workflow: { site_id, workflow_id }` → verify `{ executionId, workflowId }` returned
- [ ] Call `data_workflows_tool` with `get_workflow_execution_status: { site_id, execution_id }` → verify `{ status, isFinished }` returned
- [ ] Call with an inactive workflow → verify `400` surfaced via `formatErrorResponse`
- [ ] All three actions (`list_workflows`, `execute_workflow`, `get_workflow_execution_status`) work in the same `actions` array call

🤖 Generated with [Claude Code](https://claude.com/claude-code)