### PR TITLE
refactor: enhance tools registration with access token support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,21 +26,31 @@ function getClient() {
   return webflowClient;
 }
 
+// Return the Webflow access token
+function getAccessToken() {
+  if (!process.env.WEBFLOW_TOKEN) {
+    throw new Error("WEBFLOW_TOKEN is missing");
+  }
+  return process.env.WEBFLOW_TOKEN || "";
+}
+
 // Configure and run local MCP server (stdio transport)
 async function run() {
   const server = createMcpServer();
   const { callTool } = await initDesignerAppBridge();
   registerMiscTools(server);
-  registerTools(server, getClient);
+  registerTools(server, getClient, getAccessToken);
   registerDesignerTools(server, {
     callTool,
     getClient,
+    getAccessToken,
   });
 
   //Only valid for OSS MCP Version.
   registerLocalTools(server, {
     callTool,
     getClient,
+    getAccessToken,
   });
 
   const transport = new StdioServerTransport();

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -32,7 +32,7 @@ export function createMcpServer() {
     },
     {
       instructions: `These tools give you access to the Webflow's Data API. If you are ever unsure about anything Webflow API-related, use the "ask_webflow_ai" tool.`,
-    }
+    },
   );
 }
 
@@ -46,7 +46,8 @@ export const requestOptions = {
 // Register tools
 export function registerTools(
   server: McpServer,
-  getClient: () => WebflowClient
+  getClient: () => WebflowClient,
+  getAccessToken: () => string,
 ) {
   registerAiChatTools(server);
   registerCmsTools(server, getClient);

--- a/src/types/RPCType.d.ts
+++ b/src/types/RPCType.d.ts
@@ -3,4 +3,5 @@ import { WebflowClient } from "webflow-api";
 export type RPCType = {
   callTool: (toolName: string, args?: any) => Promise<any>;
   getClient: () => WebflowClient;
+  getAccessToken: () => string;
 };


### PR DESCRIPTION
- Added `getAccessToken` function to retrieve the Webflow access token, ensuring it is available for tool registration.
- Updated `registerTools` and related functions to include the new access token parameter for improved API interactions.
- Modified type definitions to reflect the addition of the access token functionality.