### PR TITLE
feat: Component Tool - Improved Component Creation + Retrieval

### DIFF
--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -183,27 +183,24 @@ export function registerDEComponentsTools(
                 .describe(
                   "Get all components, only valid if you are connected to Webflow Designer.",
                 ),
-              get_component_by_id: z
+              get_component: z
                 .object({
                   component_id: z
                     .string()
-                    .describe("The id of the component to get"),
-                })
-                .optional()
-                .describe("Get a component by its ID"),
-              get_component_by_name: z
-                .object({
+                    .optional()
+                    .describe("The id of the component to get. Use this or name."),
                   name: z
                     .string()
-                    .describe("The name of the component"),
+                    .optional()
+                    .describe("The name of the component. Use this or component_id."),
                   group: z
                     .string()
                     .optional()
-                    .describe("Optional group to narrow the search"),
+                    .describe("Optional group to narrow the search when using name"),
                 })
                 .optional()
                 .describe(
-                  "Get a component by its name, optionally within a specific group",
+                  "Get a component by ID or by name. Provide component_id for ID lookup, or name (and optional group) for name lookup.",
                 ),
               open_component_canvas: z
                 .object({
@@ -215,7 +212,7 @@ export function registerDEComponentsTools(
                 .describe(
                   "Open the component canvas for editing a component directly",
                 ),
-              get_component_settings: z
+              get_component_metadata: z
                 .object({
                   component_id: z
                     .string()
@@ -223,9 +220,9 @@ export function registerDEComponentsTools(
                 })
                 .optional()
                 .describe(
-                  "Get the settings (name, group, description) of a component",
+                  "Get the metadata (name, group, description) of a component",
                 ),
-              set_component_settings: z
+              set_component_metadata: z
                 .object({
                   component_id: z
                     .string()
@@ -245,7 +242,7 @@ export function registerDEComponentsTools(
                 })
                 .optional()
                 .describe(
-                  "Update settings (name, group, description) of a component",
+                  "Update metadata (name, group, description) of a component",
                 ),
               rename_component: z
                 .object({
@@ -284,17 +281,16 @@ export function registerDEComponentsTools(
                   d.open_component_view,
                   d.close_component_view,
                   d.get_all_components,
-                  d.get_component_by_id,
-                  d.get_component_by_name,
+                  d.get_component,
                   d.open_component_canvas,
-                  d.get_component_settings,
-                  d.set_component_settings,
+                  d.get_component_metadata,
+                  d.set_component_metadata,
                   d.rename_component,
                   d.unregister_component,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, create_blank_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component_by_id, get_component_by_name, open_component_canvas, get_component_settings, set_component_settings, rename_component, unregister_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, create_blank_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, open_component_canvas, get_component_metadata, set_component_metadata, rename_component, unregister_component.",
               },
             ),
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -126,24 +126,6 @@ export function registerDEComponentsTools(
                 .describe(
                   "Transform an element to a component",
                 ),
-              create_blank_component: z
-                .object({
-                  name: z
-                    .string()
-                    .describe("The name of the component"),
-                  group: z
-                    .string()
-                    .optional()
-                    .describe("Optional group/category for the component"),
-                  description: z
-                    .string()
-                    .optional()
-                    .describe("Optional description for the component"),
-                })
-                .optional()
-                .describe(
-                  "Create a new blank component (not from an existing element)",
-                ),
               insert_component_instance: z
                 .object({
                   parent_element_id: DEElementIDSchema.id,
@@ -201,16 +183,6 @@ export function registerDEComponentsTools(
                 .optional()
                 .describe(
                   "Get a component by ID or by name. Provide component_id for ID lookup, or name (and optional group) for name lookup.",
-                ),
-              open_component_canvas: z
-                .object({
-                  component_id: z
-                    .string()
-                    .describe("The id of the component to open in canvas"),
-                })
-                .optional()
-                .describe(
-                  "Open the component canvas for editing a component directly",
                 ),
               get_component_metadata: z
                 .object({
@@ -276,13 +248,11 @@ export function registerDEComponentsTools(
                 [
                   d.check_if_inside_component_view,
                   d.transform_element_to_component,
-                  d.create_blank_component,
                   d.insert_component_instance,
                   d.open_component_view,
                   d.close_component_view,
                   d.get_all_components,
                   d.get_component,
-                  d.open_component_canvas,
                   d.get_component_metadata,
                   d.set_component_metadata,
                   d.rename_component,
@@ -290,7 +260,7 @@ export function registerDEComponentsTools(
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, create_blank_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, open_component_canvas, get_component_metadata, set_component_metadata, rename_component, unregister_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component.",
               },
             ),
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -113,10 +113,36 @@ export function registerDEComponentsTools(
                   name: z
                     .string()
                     .describe("The name of the component"),
+                  group: z
+                    .string()
+                    .optional()
+                    .describe("Optional group/category for the component"),
+                  description: z
+                    .string()
+                    .optional()
+                    .describe("Optional description for the component"),
                 })
                 .optional()
                 .describe(
                   "Transform an element to a component",
+                ),
+              create_blank_component: z
+                .object({
+                  name: z
+                    .string()
+                    .describe("The name of the component"),
+                  group: z
+                    .string()
+                    .optional()
+                    .describe("Optional group/category for the component"),
+                  description: z
+                    .string()
+                    .optional()
+                    .describe("Optional description for the component"),
+                })
+                .optional()
+                .describe(
+                  "Create a new blank component (not from an existing element)",
                 ),
               insert_component_instance: z
                 .object({
@@ -157,6 +183,70 @@ export function registerDEComponentsTools(
                 .describe(
                   "Get all components, only valid if you are connected to Webflow Designer.",
                 ),
+              get_component_by_id: z
+                .object({
+                  component_id: z
+                    .string()
+                    .describe("The id of the component to get"),
+                })
+                .optional()
+                .describe("Get a component by its ID"),
+              get_component_by_name: z
+                .object({
+                  name: z
+                    .string()
+                    .describe("The name of the component"),
+                  group: z
+                    .string()
+                    .optional()
+                    .describe("Optional group to narrow the search"),
+                })
+                .optional()
+                .describe(
+                  "Get a component by its name, optionally within a specific group",
+                ),
+              open_component_canvas: z
+                .object({
+                  component_id: z
+                    .string()
+                    .describe("The id of the component to open in canvas"),
+                })
+                .optional()
+                .describe(
+                  "Open the component canvas for editing a component directly",
+                ),
+              get_component_settings: z
+                .object({
+                  component_id: z
+                    .string()
+                    .describe("The id of the component"),
+                })
+                .optional()
+                .describe(
+                  "Get the settings (name, group, description) of a component",
+                ),
+              set_component_settings: z
+                .object({
+                  component_id: z
+                    .string()
+                    .describe("The id of the component"),
+                  name: z
+                    .string()
+                    .optional()
+                    .describe("New name for the component"),
+                  group: z
+                    .string()
+                    .optional()
+                    .describe("New group for the component"),
+                  description: z
+                    .string()
+                    .optional()
+                    .describe("New description for the component"),
+                })
+                .optional()
+                .describe(
+                  "Update settings (name, group, description) of a component",
+                ),
               rename_component: z
                 .object({
                   component_id: z
@@ -189,16 +279,22 @@ export function registerDEComponentsTools(
                 [
                   d.check_if_inside_component_view,
                   d.transform_element_to_component,
+                  d.create_blank_component,
                   d.insert_component_instance,
                   d.open_component_view,
                   d.close_component_view,
                   d.get_all_components,
+                  d.get_component_by_id,
+                  d.get_component_by_name,
+                  d.open_component_canvas,
+                  d.get_component_settings,
+                  d.set_component_settings,
                   d.rename_component,
                   d.unregister_component,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, rename_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, create_blank_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component_by_id, get_component_by_name, open_component_canvas, get_component_settings, set_component_settings, rename_component, unregister_component.",
               },
             ),
         ),


### PR DESCRIPTION
## Summary

Add Zod schemas for 6 new `de_component_tool` actions exposing Webflow Designer Extension component APIs, and extend `transform_element_to_component` with optional metadata fields.

## New Actions

| Action | Webflow API | Jira |
|--------|------------|------|
| `get_component_by_id` | `webflow.getComponent(id)` | STRUCT-3592 |
| `get_component_by_name` | `webflow.getComponentByName(name)` / `(group, name)` | STRUCT-3615 |
| `get_component_settings` | `component.getSettings()` | STRUCT-3527 |
| `set_component_settings` | `component.setSettings(partial)` | STRUCT-3527 |
| `transform_element_to_component` (extended) | Added optional `group`, `description` params | STRUCT-3525 |

## Changes

- `src/tools/deComponents.ts`: 6 new action schemas, extended `transform_element_to_component`, updated `.refine()` validator

## Test plan

- [ ] Build passes: `npm run build`
- [ ] Existing component actions still work
- [ ] New action schemas validate via MCP Inspector
- [ ] End-to-end test via Cursor with bridge app connected