### PR TITLE
feat(workflows): add create_workflow action to data_workflows_tool

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -59,6 +59,7 @@ export function registerTools(
   registerCommentsTools(server, getClient);
   registerEnterpriseTools(server, getClient);
   registerWebhookTools(server, getClient);
+  registerWorkflowsTools(server, getAccessToken);
 }
 
 export function registerWorkflowTools(

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -10,19 +10,18 @@ import {
 
 const WEBFLOW_API_BASE = "https://api.webflow.com";
 
-async function listWorkflows(arg: {
-  site_id: string;
-  token: string;
-}): Promise<unknown> {
-  const response = await fetch(
-    `${WEBFLOW_API_BASE}/v2/sites/${arg.site_id}/workflows`,
-    {
-      headers: {
-        Authorization: `Bearer ${arg.token}`,
-        ...requestOptions.headers,
-      },
-    }
-  );
+async function apiRequest(
+  method: string,
+  path: string,
+  token: string
+): Promise<unknown> {
+  const response = await fetch(`${WEBFLOW_API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...requestOptions.headers,
+    },
+  });
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));
@@ -45,11 +44,11 @@ export function registerWorkflowsTools(
     {
       title: "Data Workflows Tool",
       annotations: {
-        readOnlyHint: true,
+        readOnlyHint: false,
         openWorldHint: false,
       },
       description:
-        "Data tool - Workflows tool to perform actions like listing AI workflows configured for a site.",
+        "Data tool - Workflows tool to list AI workflows, execute a workflow, and poll execution status.",
       inputSchema: {
         actions: z.array(
           z
@@ -65,11 +64,50 @@ export function registerWorkflowsTools(
                 .describe(
                   "List all AI workflows configured for a site. Returns each workflow's ID, name, active status, and template slug."
                 ),
+              // POST https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/execute
+              execute_workflow: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  workflow_id: z
+                    .string()
+                    .describe("Unique identifier for the workflow to execute."),
+                })
+                .optional()
+                .describe(
+                  "Execute an AI workflow. The workflow must be active. Returns an execution_id to poll with get_workflow_execution_status."
+                ),
+              // GET https://api.webflow.com/v2/sites/:site_id/workflows/executions/:execution_id
+              get_workflow_execution_status: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  execution_id: z
+                    .string()
+                    .describe(
+                      "Execution ID returned by execute_workflow. Poll until isFinished is true."
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get the status of a workflow execution. Returns status, start/stop times, and isFinished."
+                ),
             })
             .strict()
-            .refine((d) => [d.list_workflows].filter(Boolean).length >= 1, {
-              message: "Provide at least one of list_workflows.",
-            })
+            .refine(
+              (d) =>
+                [
+                  d.list_workflows,
+                  d.execute_workflow,
+                  d.get_workflow_execution_status,
+                ].filter(Boolean).length >= 1,
+              {
+                message:
+                  "Provide at least one of list_workflows, execute_workflow, get_workflow_execution_status.",
+              }
+            )
         ),
       },
     },
@@ -78,10 +116,27 @@ export function registerWorkflowsTools(
       try {
         for (const action of actions) {
           if (action.list_workflows) {
-            const content = await listWorkflows({
-              site_id: action.list_workflows.site_id,
-              token: getToken(),
-            });
+            const content = await apiRequest(
+              "GET",
+              `/v2/sites/${action.list_workflows.site_id}/workflows`,
+              getToken()
+            );
+            result.push(textContent(content));
+          }
+          if (action.execute_workflow) {
+            const content = await apiRequest(
+              "POST",
+              `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
+              getToken()
+            );
+            result.push(textContent(content));
+          }
+          if (action.get_workflow_execution_status) {
+            const content = await apiRequest(
+              "GET",
+              `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
+              getToken()
+            );
             result.push(textContent(content));
           }
         }

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -51,7 +51,7 @@ export function registerWorkflowsTools(
         openWorldHint: false,
       },
       description:
-        "Data tool - Workflows tool to list AI workflows, create a workflow from a template, execute a workflow, and poll execution status.",
+        "Data tool - Workflows tool to list AI workflows, create a workflow from a template, run a workflow, and get a workflow run.",
       inputSchema: {
         actions: z.array(
           z
@@ -67,35 +67,38 @@ export function registerWorkflowsTools(
                 .describe(
                   "List all AI workflows configured for a site. Returns each workflow's ID, name, active status, and template slug."
                 ),
-              // POST https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/execute
-              execute_workflow: z
+              // POST https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/run
+              run_workflow: z
                 .object({
                   site_id: z
                     .string()
                     .describe("Unique identifier for the site."),
                   workflow_id: z
                     .string()
-                    .describe("Unique identifier for the workflow to execute."),
+                    .describe("Unique identifier for the workflow to run."),
                 })
                 .optional()
                 .describe(
-                  "Execute an AI workflow. The workflow must be active. Returns an execution_id to poll with get_workflow_execution_status."
+                  "Run an AI workflow. The workflow must be active. Returns a run_id to poll with get_workflow_run."
                 ),
-              // GET https://api.webflow.com/v2/sites/:site_id/workflows/executions/:execution_id
-              get_workflow_execution_status: z
+              // GET https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/runs/:run_id
+              get_workflow_run: z
                 .object({
                   site_id: z
                     .string()
                     .describe("Unique identifier for the site."),
-                  execution_id: z
+                  workflow_id: z
+                    .string()
+                    .describe("Unique identifier for the workflow."),
+                  run_id: z
                     .string()
                     .describe(
-                      "Execution ID returned by execute_workflow. Poll until isFinished is true."
+                      "Run ID returned by run_workflow. Poll until isFinished is true."
                     ),
                 })
                 .optional()
                 .describe(
-                  "Get the status of a workflow execution. Returns status, start/stop times, and isFinished."
+                  "Get the status of a workflow run. Returns status, start/stop times, and isFinished."
                 ),
               // POST https://api.webflow.com/v2/sites/:site_id/workflows
               create_workflow: z
@@ -119,13 +122,13 @@ export function registerWorkflowsTools(
               (d) =>
                 [
                   d.list_workflows,
-                  d.execute_workflow,
-                  d.get_workflow_execution_status,
+                  d.run_workflow,
+                  d.get_workflow_run,
                   d.create_workflow,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of list_workflows, execute_workflow, get_workflow_execution_status, create_workflow.",
+                  "Provide at least one of list_workflows, run_workflow, get_workflow_run, create_workflow.",
               }
             )
         ),
@@ -143,18 +146,18 @@ export function registerWorkflowsTools(
             );
             result.push(textContent(content));
           }
-          if (action.execute_workflow) {
+          if (action.run_workflow) {
             const content = await apiRequest(
               "POST",
-              `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
+              `/v2/sites/${action.run_workflow.site_id}/workflows/${action.run_workflow.workflow_id}/run`,
               getToken()
             );
             result.push(textContent(content));
           }
-          if (action.get_workflow_execution_status) {
+          if (action.get_workflow_run) {
             const content = await apiRequest(
               "GET",
-              `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
+              `/v2/sites/${action.get_workflow_run.site_id}/workflows/${action.get_workflow_run.workflow_id}/runs/${action.get_workflow_run.run_id}`,
               getToken()
             );
             result.push(textContent(content));

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -13,14 +13,17 @@ const WEBFLOW_API_BASE = "https://api.webflow.com";
 async function apiRequest(
   method: string,
   path: string,
-  token: string
+  token: string,
+  body?: Record<string, unknown>
 ): Promise<unknown> {
   const response = await fetch(`${WEBFLOW_API_BASE}${path}`, {
     method,
     headers: {
       Authorization: `Bearer ${token}`,
       ...requestOptions.headers,
+      ...(body ? { "Content-Type": "application/json" } : {}),
     },
+    ...(body ? { body: JSON.stringify(body) } : {}),
   });
 
   if (!response.ok) {
@@ -48,7 +51,7 @@ export function registerWorkflowsTools(
         openWorldHint: false,
       },
       description:
-        "Data tool - Workflows tool to list AI workflows, execute a workflow, and poll execution status.",
+        "Data tool - Workflows tool to list AI workflows, create a workflow from a template, execute a workflow, and poll execution status.",
       inputSchema: {
         actions: z.array(
           z
@@ -94,6 +97,22 @@ export function registerWorkflowsTools(
                 .describe(
                   "Get the status of a workflow execution. Returns status, start/stop times, and isFinished."
                 ),
+              // POST https://api.webflow.com/v2/sites/:site_id/workflows
+              create_workflow: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  template_slug: z
+                    .string()
+                    .describe(
+                      "Template slug to create the workflow from (e.g. 'content-brief-generator')."
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Create a new AI workflow for a site from a template. Returns the created workflow's ID, name, active status, and template slug."
+                ),
             })
             .strict()
             .refine(
@@ -102,10 +121,11 @@ export function registerWorkflowsTools(
                   d.list_workflows,
                   d.execute_workflow,
                   d.get_workflow_execution_status,
+                  d.create_workflow,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of list_workflows, execute_workflow, get_workflow_execution_status.",
+                  "Provide at least one of list_workflows, execute_workflow, get_workflow_execution_status, create_workflow.",
               }
             )
         ),
@@ -136,6 +156,15 @@ export function registerWorkflowsTools(
               "GET",
               `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
               getToken()
+            );
+            result.push(textContent(content));
+          }
+          if (action.create_workflow) {
+            const content = await apiRequest(
+              "POST",
+              `/v2/sites/${action.create_workflow.site_id}/workflows`,
+              getToken(),
+              { templateSlug: action.create_workflow.template_slug }
             );
             result.push(textContent(content));
           }


### PR DESCRIPTION
## Summary

- Adds `create_workflow` action to `data_workflows_tool`, following the same pattern as `list_workflows`, `execute_workflow`, and `get_workflow_execution_status`
- Updates `apiRequest` to accept an optional `body` parameter, enabling POST requests with a JSON payload
- Gated by the same `registerWorkflowsTools` / `registerWorkflowTools` registration as the existing workflow actions

## API

`POST /v2/sites/:site_id/workflows` with body `{ templateSlug: string }`

## Test plan

- [ ] Call `create_workflow` with a valid `site_id` and `template_slug` (e.g. `content-brief-generator`) — should return created workflow with ID, name, active status, and template slug
- [ ] Verify existing actions (`list_workflows`, `execute_workflow`, `get_workflow_execution_status`) are unaffected
- [ ] Verify `apiRequest` calls without a body still work (no `Content-Type` header sent on GETs)