### PR TITLE
fix(workflows): update workflow endpoints to match new API naming

### DIFF
--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -39,8 +39,8 @@ async function apiRequest(
 async function handleWorkflowActions(
   actions: Array<{
     list_workflows?: { site_id: string };
-    execute_workflow?: { site_id: string; workflow_id: string };
-    get_workflow_execution_status?: { site_id: string; execution_id: string };
+    run_workflow?: { site_id: string; workflow_id: string };
+    get_workflow_run?: { site_id: string; workflow_id: string; run_id: string };
   }>,
   getToken: () => string
 ): Promise<Content[]> {
@@ -55,20 +55,20 @@ async function handleWorkflowActions(
         )
       );
     }
-    if (action.execute_workflow) {
+    if (action.run_workflow) {
       result.push(
         await apiRequest(
           "POST",
-          `/v2/sites/${action.execute_workflow.site_id}/workflows/${action.execute_workflow.workflow_id}/execute`,
+          `/v2/sites/${action.run_workflow.site_id}/workflows/${action.run_workflow.workflow_id}/run`,
           getToken
         )
       );
     }
-    if (action.get_workflow_execution_status) {
+    if (action.get_workflow_run) {
       result.push(
         await apiRequest(
           "GET",
-          `/v2/sites/${action.get_workflow_execution_status.site_id}/workflows/executions/${action.get_workflow_execution_status.execution_id}`,
+          `/v2/sites/${action.get_workflow_run.site_id}/workflows/${action.get_workflow_run.workflow_id}/runs/${action.get_workflow_run.run_id}`,
           getToken
         )
       );
@@ -90,7 +90,7 @@ export function registerWorkflowsTools(
         openWorldHint: false,
       },
       description:
-        "Data tool - Workflows tool to list AI workflows, execute a workflow, and poll execution status.",
+        "Data tool - Workflows tool to list AI workflows, run a workflow, and get a workflow run.",
       inputSchema: {
         actions: z.array(
           z
@@ -106,35 +106,38 @@ export function registerWorkflowsTools(
                 .describe(
                   "List all AI workflows configured for a site. Returns each workflow's ID, name, active status, and template slug."
                 ),
-              // POST https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/execute
-              execute_workflow: z
+              // POST https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/run
+              run_workflow: z
                 .object({
                   site_id: z
                     .string()
                     .describe("Unique identifier for the site."),
                   workflow_id: z
                     .string()
-                    .describe("Unique identifier for the workflow to execute."),
+                    .describe("Unique identifier for the workflow to run."),
                 })
                 .optional()
                 .describe(
-                  "Execute an AI workflow. The workflow must be active. Returns an execution_id to poll with get_workflow_execution_status."
+                  "Run an AI workflow. The workflow must be active. Returns a run_id to poll with get_workflow_run."
                 ),
-              // GET https://api.webflow.com/v2/sites/:site_id/workflows/executions/:execution_id
-              get_workflow_execution_status: z
+              // GET https://api.webflow.com/v2/sites/:site_id/workflows/:workflow_id/runs/:run_id
+              get_workflow_run: z
                 .object({
                   site_id: z
                     .string()
                     .describe("Unique identifier for the site."),
-                  execution_id: z
+                  workflow_id: z
+                    .string()
+                    .describe("Unique identifier for the workflow."),
+                  run_id: z
                     .string()
                     .describe(
-                      "Execution ID returned by execute_workflow. Poll until isFinished is true."
+                      "Run ID returned by run_workflow. Poll until isFinished is true."
                     ),
                 })
                 .optional()
                 .describe(
-                  "Get the status of a workflow execution. Returns status, start/stop times, and isFinished."
+                  "Get the status of a workflow run. Returns status, start/stop times, and isFinished."
                 ),
             })
             .strict()
@@ -142,12 +145,12 @@ export function registerWorkflowsTools(
               (d) =>
                 [
                   d.list_workflows,
-                  d.execute_workflow,
-                  d.get_workflow_execution_status,
+                  d.run_workflow,
+                  d.get_workflow_run,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of list_workflows, execute_workflow, get_workflow_execution_status.",
+                  "Provide at least one of list_workflows, run_workflow, get_workflow_run.",
               }
             )
         ),


### PR DESCRIPTION
## Summary
- Renames `execute_workflow` → `run_workflow` with updated endpoint `POST .../workflows/:workflow_id/run`
- Renames `get_workflow_execution_status` → `get_workflow_run` with updated endpoint `GET .../workflows/:workflow_id/runs/:run_id`
- Adds required `workflow_id` param to `get_workflow_run` to match new endpoint shape

Mirrors changes from webflow/webflow#102297.

## Test plan
- [ ] Run a workflow and confirm `run_workflow` action hits the correct `/run` endpoint
- [ ] Poll status with `get_workflow_run` using `workflow_id` + `run_id` and confirm correct response

🤖 Generated with [Claude Code](https://claude.com/claude-code)