### PR TITLE
Add component management and canvas navigation schemas

### DIFF
--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -257,17 +257,29 @@ export function registerDEComponentsTools(
                 })
                 .optional()
                 .describe(
-                  "[BETA] Create a blank component with no root element. Equivalent to 'Create blank' in the Designer's New Component menu.",
+                  "Create a blank component with no root element. Equivalent to 'Create blank' in the Designer's New Component menu.",
                 ),
               open_component_canvas: z
                 .object({
                   component_id: z
                     .string()
-                    .describe("The id of the component to open in the canvas"),
+                    .optional()
+                    .describe("The id of the component to open in the canvas. Use this or component_instance_id."),
+                  component_instance_id: z
+                    .object({
+                      component: z
+                        .string()
+                        .describe("The component id of the instance element."),
+                      element: z
+                        .string()
+                        .describe("The element id of the instance element."),
+                    })
+                    .optional()
+                    .describe("The element ID of a component instance to open in the canvas. Use this or component_id."),
                 })
                 .optional()
                 .describe(
-                  "[BETA] Open a component's canvas directly by component ID, without needing a component instance on the page.",
+                  "Open a component's canvas directly by component ID or component instance element ID.",
                 ),
             })
             .strict()

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -316,6 +316,18 @@ export function registerDEComponentsTools(
                 .describe(
                   "Get the component that contains the specified element. Returns null if the element is at page level (not inside a component).",
                 ),
+              insert_slot: z
+                .object({
+                  parent_element_id: DEElementIDSchema.id,
+                  position: z
+                    .enum(["append", "prepend", "before", "after"])
+                    .optional()
+                    .describe("Insertion position relative to the parent element. Defaults to 'append'."),
+                })
+                .optional()
+                .describe(
+                  "Insert a Slot element into the currently-editing component. Must be inside component editing context (use open_component_canvas or open_component_view first). A SlotContent prop is automatically created.",
+                ),
             })
             .strict()
             .refine(
@@ -338,10 +350,11 @@ export function registerDEComponentsTools(
                   d.get_instance_count,
                   d.get_current_component,
                   d.get_parent_component,
+                  d.insert_slot,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_component_canvas, search_components, get_instance_count, get_current_component, get_parent_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_component_canvas, search_components, get_instance_count, get_current_component, get_parent_component, insert_slot.",
               },
             ),
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -259,27 +259,20 @@ export function registerDEComponentsTools(
                 .describe(
                   "Create a blank component with no root element. Equivalent to 'Create blank' in the Designer's New Component menu.",
                 ),
-              open_component_canvas: z
+              open_canvas: z
                 .object({
                   component_id: z
                     .string()
                     .optional()
-                    .describe("The id of the component to open in the canvas. Use this or component_instance_id."),
-                  component_instance_id: z
-                    .object({
-                      component: z
-                        .string()
-                        .describe("The component id of the instance element."),
-                      element: z
-                        .string()
-                        .describe("The element id of the instance element."),
-                    })
+                    .describe("The id of the component to open in the canvas. Use this or page_id."),
+                  page_id: z
+                    .string()
                     .optional()
-                    .describe("The element ID of a component instance to open in the canvas. Use this or component_id."),
+                    .describe("The id of the page to navigate to. Use this to exit the component canvas and return to a page."),
                 })
                 .optional()
                 .describe(
-                  "Open a component's canvas directly by component ID or component instance element ID.",
+                  "Navigate the Designer canvas to a component or page. Use component_id to open a component canvas, or page_id to navigate to a page (e.g. to exit component canvas). Provide exactly one of component_id or page_id.",
                 ),
               search_components: z
                 .object({
@@ -326,7 +319,7 @@ export function registerDEComponentsTools(
                 })
                 .optional()
                 .describe(
-                  "Insert a Slot element into the currently-editing component. Must be inside component editing context (use open_component_canvas or open_component_view first). A SlotContent prop is automatically created.",
+                  "Insert a Slot element into the currently-editing component. Must be inside component editing context (use open_canvas or open_component_view first). A SlotContent prop is automatically created.",
                 ),
             })
             .strict()
@@ -345,7 +338,7 @@ export function registerDEComponentsTools(
                   d.rename_component,
                   d.unregister_component,
                   d.create_blank_component,
-                  d.open_component_canvas,
+                  d.open_canvas,
                   d.search_components,
                   d.get_instance_count,
                   d.get_current_component,
@@ -354,7 +347,7 @@ export function registerDEComponentsTools(
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_component_canvas, search_components, get_instance_count, get_current_component, get_parent_component, insert_slot.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_canvas, search_components, get_instance_count, get_current_component, get_parent_component, insert_slot.",
               },
             ),
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -241,6 +241,34 @@ export function registerDEComponentsTools(
                 .describe(
                   "Unregister a component. DANGEROUS ACTION. USE WITH CAUTION.",
                 ),
+              create_blank_component: z
+                .object({
+                  name: z
+                    .string()
+                    .describe("The name of the blank component to create"),
+                  group: z
+                    .string()
+                    .optional()
+                    .describe("Optional group/folder to place the component in"),
+                  description: z
+                    .string()
+                    .optional()
+                    .describe("Optional description for the component"),
+                })
+                .optional()
+                .describe(
+                  "[BETA] Create a blank component with no root element. Equivalent to 'Create blank' in the Designer's New Component menu.",
+                ),
+              open_component_canvas: z
+                .object({
+                  component_id: z
+                    .string()
+                    .describe("The id of the component to open in the canvas"),
+                })
+                .optional()
+                .describe(
+                  "[BETA] Open a component's canvas directly by component ID, without needing a component instance on the page.",
+                ),
             })
             .strict()
             .refine(
@@ -257,10 +285,12 @@ export function registerDEComponentsTools(
                   d.set_component_metadata,
                   d.rename_component,
                   d.unregister_component,
+                  d.create_blank_component,
+                  d.open_component_canvas,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_component_canvas.",
               },
             ),
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -281,6 +281,41 @@ export function registerDEComponentsTools(
                 .describe(
                   "Open a component's canvas directly by component ID or component instance element ID.",
                 ),
+              search_components: z
+                .object({
+                  q: z
+                    .string()
+                    .optional()
+                    .describe("Optional fuzzy search query matching Component panel search behavior. Searches both name and description fields."),
+                })
+                .optional()
+                .describe(
+                  "Search all components in the project. Returns component metadata including name, group, description, instance count, editability, and library info. When called without a query, returns all components.",
+                ),
+              get_instance_count: z
+                .object({
+                  component_id: z
+                    .string()
+                    .describe("The id of the component to get the instance count for"),
+                })
+                .optional()
+                .describe(
+                  "Get the number of instances of a component across the site. Returns the same count shown in the Components panel.",
+                ),
+              get_current_component: z
+                .boolean()
+                .optional()
+                .describe(
+                  "Get the component currently being edited on the canvas (in-context editing or component canvas). Returns null if on a regular page.",
+                ),
+              get_parent_component: z
+                .object({
+                  ...DEElementIDSchema,
+                })
+                .optional()
+                .describe(
+                  "Get the component that contains the specified element. Returns null if the element is at page level (not inside a component).",
+                ),
             })
             .strict()
             .refine(
@@ -299,10 +334,14 @@ export function registerDEComponentsTools(
                   d.unregister_component,
                   d.create_blank_component,
                   d.open_component_canvas,
+                  d.search_components,
+                  d.get_instance_count,
+                  d.get_current_component,
+                  d.get_parent_component,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_component_canvas.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, create_blank_component, open_component_canvas, search_components, get_instance_count, get_current_component, get_parent_component.",
               },
             ),
         ),

--- a/src/tools/dePages.ts
+++ b/src/tools/dePages.ts
@@ -75,6 +75,16 @@ export function registerDEPagesTools(server: McpServer, rpc: RPCType) {
                 })
                 .optional()
                 .describe("Switch to a page on webflow designer"),
+              open_page_canvas: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("The id of the page to open in the canvas"),
+                })
+                .optional()
+                .describe(
+                  "Navigate the Designer canvas to a specific page by page ID.",
+                ),
             })
             .strict()
             .refine(
@@ -84,10 +94,11 @@ export function registerDEPagesTools(server: McpServer, rpc: RPCType) {
                   d.create_page_folder,
                   d.get_current_page,
                   d.switch_page,
+                  d.open_page_canvas,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of create_page, create_page_folder, get_current_page, switch_page.",
+                  "Provide at least one of create_page, create_page_folder, get_current_page, switch_page, open_page_canvas.",
               }
             )
         ),

--- a/src/tools/rules.ts
+++ b/src/tools/rules.ts
@@ -54,12 +54,24 @@ export function registerRulesTools(server: McpServer) {
             `\n` +
             `Component Tool (Designer):\n` +
             `-- To get all components in the site, use de_component_tool > get_all_components.\n` +
+            `-- To search components by name or description, use de_component_tool > search_components. Pass an optional query string. Returns rich metadata including name, group, description, instance count, editability, and library info.\n` +
             `-- To insert a component instance by component ID, use de_component_tool > insert_component_instance. Pass parent_element_id, component_id, and creation_position.\n` +
             `-- To transform an existing element into a component, use de_component_tool > transform_element_to_component. Pass the element ID and component name.\n` +
-            `-- To open a component view for editing, use de_component_tool > open_component_view. Pass the component_instance_id.\n` +
-            `-- To close a component view and return to page view, use de_component_tool > close_component_view.\n` +
+            `-- To create a new blank component, use de_component_tool > create_blank_component. Pass name, and optionally group and description.\n` +
+            `-- To get the number of instances of a component, use de_component_tool > get_instance_count. Pass the component_id.\n` +
+            `-- To get the component currently being edited, use de_component_tool > get_current_component. Returns null if on a regular page.\n` +
+            `-- To get the component that contains a specific element, use de_component_tool > get_parent_component. Pass the element ID. Returns null if the element is at page level.\n` +
+            `-- To insert a Slot element into a component, use de_component_tool > insert_slot. Pass parent_element_id. You must be in component editing context first (use open_canvas with a component_id).\n` +
             `-- To rename a component, use de_component_tool > rename_component. Pass component_id and new_name.\n` +
             `-- To check if you are currently inside a component view, use de_component_tool > check_if_inside_component_view.\n` +
+            `\n` +
+            `Canvas Navigation (Designer):\n` +
+            `-- To navigate the Designer canvas, use de_component_tool > open_canvas. This is the primary way to switch between component canvas and page canvas.\n` +
+            `---- To open a component canvas: pass component_id.\n` +
+            `---- To exit component canvas and return to a page: pass page_id.\n` +
+            `-- open_canvas is different from open_component_view/close_component_view. open_canvas switches the entire canvas context (like clicking a component in the Components panel). open_component_view/close_component_view enters/exits in-context editing of a component instance on the current page.\n` +
+            `-- To enter in-context editing of a component instance, use de_component_tool > open_component_view. Pass the component_instance_id.\n` +
+            `-- To exit in-context editing and return to page view, use de_component_tool > close_component_view.\n` +
             `\n` +
             `Element Snapshot Tool Usage:\n` +
             `-- To get a visual snapshot of an element, section, or component, use element_snapshot_tool. Pass the element ID to capture its current visual state as an image.\n` +


### PR DESCRIPTION
## Summary

Adds Zod schemas for new beta component tool actions and canvas navigation to `de_component_tool`, plus updated guidance in `webflow_guide_tool`.

### New actions (all beta-gated)

| Action | DE API | Jira |
|--------|--------|------|
| `create_blank_component` | `webflow.registerComponent(options)` | [STRUCT-3521](https://webflow.atlassian.net/browse/STRUCT-3521) |
| `open_canvas` | `webflow.openCanvas(component \| { pageId })` | [STRUCT-3559](https://webflow.atlassian.net/browse/STRUCT-3559) |
| `search_components` | `webflow.searchComponents({ q? })` | [STRUCT-3560](https://webflow.atlassian.net/browse/STRUCT-3560), [STRUCT-3684](https://webflow.atlassian.net/browse/STRUCT-3684) |
| `get_instance_count` | `component.getInstanceCount()` | [STRUCT-3526](https://webflow.atlassian.net/browse/STRUCT-3526) |
| `get_current_component` | `webflow.getCurrentComponent()` | [STRUCT-3660](https://webflow.atlassian.net/browse/STRUCT-3660) |
| `get_parent_component` | `element.getParentComponent()` | [STRUCT-3661](https://webflow.atlassian.net/browse/STRUCT-3661) |
| `insert_slot` | `el.append(webflow.elementPresets.Slot)` | [STRUCT-3587](https://webflow.atlassian.net/browse/STRUCT-3587) |
| `open_page_canvas` (page tool) | `webflow.openCanvas({ pageId })` | [STRUCT-3620](https://webflow.atlassian.net/browse/STRUCT-3620) |

### Rules updates
- Added guidance for all new beta component actions
- New "Canvas Navigation" section explaining `open_canvas` vs `open_component_view`/`close_component_view`

### Notes
- `open_canvas` replaces the previous `open_component_canvas` and now accepts either `component_id` or `page_id`
- TODO: Consider removing `open_page_canvas` from `de_page_tool` in the future to reduce redundancy with `open_canvas`

## Test plan

Use the beta SSE endpoint (`/beta/sse`) in Cursor and run the following prompt:

```
Test all beta component tool actions. Follow each step in order, verifying success before continuing. Use the de_component_tool with the beta endpoint.

1. Search Components (no query — list all)
   - Call search_components with no q parameter
   - Report back the list of components found with their names, groups, and instance counts

2. Search Components (with query)
   - Call search_components with q set to a name from step 1 (pick the first one)
   - Confirm the filtered results match

3. Search Components (by description)
   - Call search_components with q set to a keyword from a component's description (if any were returned in step 1)

4. Create Blank Component (name only)
   - Call create_blank_component with name: "MCP Test Component"
   - Save the returned component ID

5. Create Blank Component (with group and description)
   - Call create_blank_component with name: "MCP Test Component 2", group: "MCP Test Group", description: "Created by MCP test prompt"
   - Save the returned component ID

6. Get Instance Count (zero instances)
   - Call get_instance_count with the component_id from step 4
   - Confirm count is 0

7. Search Components (verify new components appear)
   - Call search_components with q: "MCP Test"
   - Confirm both components from steps 4 and 5 appear

8. Open Canvas (component by ID)
   - Call open_canvas with component_id from step 4
   - Confirm success

9. Get Current Component (while on component canvas)
   - Call get_current_component
   - Confirm it returns the component from step 4

10. Insert Slot (default append)
    - Get the root element of the current view
    - Call insert_slot with the root element's ID
    - Confirm the returned SlotElement info

11. Insert Slot (prepend)
    - Call insert_slot with same root element ID and position: "prepend"
    - Confirm a second slot was created

12. Get Parent Component (element inside component)
    - Using the slot element ID from step 10, call get_parent_component
    - Confirm it returns the component from step 4

13. Open Canvas (navigate to second component)
    - Call open_canvas with component_id from step 5
    - Confirm success

14. Get Current Component (verify switch)
    - Call get_current_component
    - Confirm it now returns the component from step 5

15. Open Canvas (exit to page)
    - Call open_canvas with a page_id to return to a page
    - Confirm success

16. Get Current Component (while on page)
    - Call get_current_component
    - Confirm it returns null

17. Get Parent Component (page-level element)
    - Select any element on the page, call get_parent_component with its ID
    - Confirm it returns null

18. Get Instance Count (after inserting instance)
    - Insert an instance of "MCP Test Component" onto the page using insert_component_instance
    - Call get_instance_count with component_id from step 4
    - Confirm count is now 1

19. Cleanup
    - Unregister both test components
    - Confirm both are removed

After each step, report: action name, status (success/error), and key data returned.
```

### Expected results
- All 19 steps should return `status: "success"` (except step 16/17 which return success with null data)
- `search_components` should return rich metadata (name, group, description, instances, canEdit, library)
- `get_current_component` should return component info on canvas, null on page
- `get_parent_component` should return component info for elements inside components, null for page-level
- `open_canvas` with `page_id` should exit component canvas
- `insert_slot` should work only inside component editing context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STRUCT-3521]: https://webflow.atlassian.net/browse/STRUCT-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRUCT-3559]: https://webflow.atlassian.net/browse/STRUCT-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRUCT-3560]: https://webflow.atlassian.net/browse/STRUCT-3560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRUCT-3684]: https://webflow.atlassian.net/browse/STRUCT-3684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRUCT-3526]: https://webflow.atlassian.net/browse/STRUCT-3526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRUCT-3660]: https://webflow.atlassian.net/browse/STRUCT-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRUCT-3661]: https://webflow.atlassian.net/browse/STRUCT-3661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ