### PR TITLE
[APPSEC-1645] [Non-Prod] Add Socket Security Tier 1 reachability scan

### DIFF
--- a/.github/workflows/socket_reachability.yml
+++ b/.github/workflows/socket_reachability.yml
@@ -58,8 +58,7 @@ jobs:
 
       - name: Run Socket Security Scan
         env:
-          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
-          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_TOKEN }}
           PYTHONUNBUFFERED: "1"
           ENABLE_REACH: ${{ github.event.inputs.enable_reachability }}
         run: |

--- a/.github/workflows/socket_reachability.yml
+++ b/.github/workflows/socket_reachability.yml
@@ -1,0 +1,81 @@
+# Socket Security Scan with Tier 1 Reachability Analysis
+#
+# This workflow scans dependencies and performs reachability analysis
+# to identify which vulnerabilities are actually reachable in the code.
+#
+# Required: SOCKET_SECURITY_API_KEY secret with enterprise plan
+# API token scopes needed: socket-basics, uploaded-artifacts, full-scans, repo
+
+name: Socket Security Scan
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # Everyday at 2 AM UTC
+  workflow_dispatch:
+    inputs:
+      enable_reachability:
+        description: "Enable Tier 1 reachability analysis"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+concurrency:
+  group: socket-security-scan
+  cancel-in-progress: true
+
+jobs:
+  socket-security:
+    name: Socket Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install uv (Python package manager)
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Socket CLI
+        run: uv pip install socketsecurity --upgrade --system
+
+      - name: Run Socket Security Scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          PYTHONUNBUFFERED: "1"
+          ENABLE_REACH: ${{ github.event.inputs.enable_reachability }}
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+
+          # Build reachability flags if enabled
+          REACH_FLAGS=""
+          if [[ "${ENABLE_REACH}" != "false" ]]; then
+            REACH_FLAGS="--reach --reach-memory-limit 16384 --reach-timeout 3600"
+            echo "Reachability analysis enabled"
+          fi
+
+          echo "Scanning repository: $REPO_NAME"
+
+          socketcli \
+            --target-path "$GITHUB_WORKSPACE" \
+            --repo "$REPO_NAME" \
+            --enable-debug \
+            $REACH_FLAGS

--- a/.github/workflows/socket_reachability.yml
+++ b/.github/workflows/socket_reachability.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Socket Security Scan
         env:
-          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_TOKEN }}
+          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           PYTHONUNBUFFERED: "1"
           ENABLE_REACH: ${{ github.event.inputs.enable_reachability }}
         run: |


### PR DESCRIPTION
## Summary
- Adds Socket Security scan workflow with Tier 1 reachability analysis
- Runs daily at 2 AM UTC and can be triggered manually
- Reachability analysis can be toggled via workflow dispatch input (enabled by default)

## Details
The workflow:
- Checks out the repo and sets up Python 3.12 + Node 20
- Installs Socket CLI via `uv`
- Runs `socketcli` with Tier 1 reachability flags (`--reach --reach-memory-limit 16384 --reach-timeout 3600`)

**Required secret:** `SOCKET_SECURITY_API_KEY` (enterprise plan) with scopes: `socket-basics`, `uploaded-artifacts`, `full-scans`, `repo`

## Test plan
- [ ] After merge, manually trigger the workflow via the "Run workflow" button to confirm it runs successfully

https://webflow.atlassian.net/browse/APPSEC-1645