### PR TITLE
fix: resolve MCP tool validation errors in beta server

### DIFF
--- a/src/tools/deElement.ts
+++ b/src/tools/deElement.ts
@@ -539,7 +539,12 @@ export const registerDEElementTools = (server: McpServer, rpc: RPCType) => {
             ],
           };
         }
-        return formatErrorResponse(new Error(message));
+        return formatErrorResponse(
+          new Error(
+            message ||
+            `Element snapshot failed with status: ${status}. Response: ${JSON.stringify({ status, message, data })}`
+          )
+        );
       } catch (error) {
         return formatErrorResponse(error);
       }

--- a/src/tools/sites.ts
+++ b/src/tools/sites.ts
@@ -79,8 +79,8 @@ export function registerSiteTools(
                     .describe("Unique identifier for the site."),
                   customDomains: z
                     .array(z.string())
-                    .default([])
                     .optional()
+                    .default([])
                     .describe(
                       "Array of custom domains to publish the site to.",
                     ),


### PR DESCRIPTION
## Summary
This PR fixes two validation errors in the beta MCP server that were causing tool failures in production.

## Issue 1: Site Publishing Fails with customDomains Validation Error

**Production Error:**
```json
{
  "message": "Validation Error: [\"Value (customDomains)'s type should be array\"]",
  "code": "validation_error",
  "statusCode": 400
}
```

**Event ID:** `evt_3BlCAWmNUYSYB94s8VTWyvCJ5d0`  
**Actor:** kelly@vector.co  
**Timestamp:** Apr 1, 2026, 10:35:26 AM

**Root Cause:**
Incorrect Zod chaining order in `sites.ts`. When `.default([])` comes before `.optional()`, the field can still be `undefined`, causing the Webflow API to reject the request.

**Before:**
```typescript
customDomains: z
  .array(z.string())
  .default([])      // ❌ Wrong order
  .optional()
```

**After:**
```typescript
customDomains: z
  .array(z.string())
  .optional()       // ✅ Correct order
  .default([])
```

**Why this works:**
In Zod, `.optional().default([])` ensures that if the field is omitted, it defaults to `[]`. With the original order, the field could be `undefined` even with `.default([])`, which caused the API validation to fail.

---

## Issue 2: Empty Error Messages in element_snapshot_tool

**Production Error:**
```json
{
  "name": "Error",
  "message": "",
  "error": {}
}
```

**Event ID:** `evt_3BpOqtX0Z2ZbizQ06We4pzL88rg`  
**Resource:** element_snapshot_tool  
**Timestamp:** Apr 2, 2026, 10:18:58 PM

**Root Cause:**
When `element_snapshot_tool`'s RPC call fails and returns an empty `message`, the error handler creates `new Error("")`, resulting in unhelpful debugging information.

**Before:**
```typescript
return formatErrorResponse(new Error(message)); // ❌ Empty message
```

**After:**
```typescript
return formatErrorResponse(
  new Error(
    message ||
    `Element snapshot failed with status: ${status}. Response: ${JSON.stringify({ status, message, data })}`
  )
);
```

**Why this works:**
Provides a fallback error message with full response details when the RPC call returns an empty message, making debugging significantly easier.

---

## Testing
- ✅ Changes applied to **beta server only** (`mcp-server-beta`)
- ✅ Stable server unchanged for safety
- ✅ Both fixes address real production errors with documented event IDs

## Files Changed
- `mcp-server-beta/src/tools/sites.ts` - Fixed customDomains Zod chaining
- `mcp-server-beta/src/tools/deElement.ts` - Fixed empty error messages

## Next Steps
After validation in beta:
1. Monitor for recurrence of these errors
2. If successful, apply to stable server
3. Consider auditing other tools for similar patterns