### PR TITLE
feat(de-components): add per-instance property override actions

### DIFF
--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -241,6 +241,55 @@ export function registerDEComponentsTools(
                 .describe(
                   "Unregister a component. DANGEROUS ACTION. USE WITH CAUTION.",
                 ),
+              set_component_instance_props: z
+                .object({
+                  ...DEElementIDSchema,
+                  overrides: z
+                    .array(
+                      z.object({
+                        prop_id: z
+                          .string()
+                          .describe(
+                            "The id of the prop on the component definition. Matches Designer SDK propId.",
+                          ),
+                        value: z
+                          .any()
+                          .describe(
+                            "Value to set for this prop on the instance. Static primitive (string/number/boolean) or object for bindings. Pass null to reset this prop to its component default.",
+                          ),
+                      }),
+                    )
+                    .min(1)
+                    .describe(
+                      "Per-instance prop overrides to apply. Wraps Designer SDK ComponentElement.setProps.",
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Set per-instance property overrides on a component instance (e.g., a Heading instance's Text prop, a Button instance's label). Only affects the target instance; does not change component defaults or other instances.",
+                ),
+              get_component_instance_props: z
+                .object({
+                  ...DEElementIDSchema,
+                  resolved: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                      "If true, return resolved prop values (bindings converted to final output). Defaults to false, which returns raw prop entries including a hasOverride flag per prop.",
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get per-instance prop values on a component instance. Wraps Designer SDK ComponentElement.getProps / getResolvedProps.",
+                ),
+              reset_component_instance_props: z
+                .object({
+                  ...DEElementIDSchema,
+                })
+                .optional()
+                .describe(
+                  "Reset all per-instance prop overrides on a component instance back to component defaults. Wraps Designer SDK ComponentElement.resetAllProps.",
+                ),
             })
             .strict()
             .refine(
@@ -257,10 +306,13 @@ export function registerDEComponentsTools(
                   d.set_component_metadata,
                   d.rename_component,
                   d.unregister_component,
+                  d.set_component_instance_props,
+                  d.get_component_instance_props,
+                  d.reset_component_instance_props,
                 ].filter(Boolean).length >= 1,
               {
                 message:
-                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component.",
+                  "Provide at least one of check_if_inside_component_view, transform_element_to_component, insert_component_instance, open_component_view, close_component_view, get_all_components, get_component, get_component_metadata, set_component_metadata, rename_component, unregister_component, set_component_instance_props, get_component_instance_props, reset_component_instance_props.",
               },
             ),
         ),

--- a/src/tools/deComponents.ts
+++ b/src/tools/deComponents.ts
@@ -253,7 +253,13 @@ export function registerDEComponentsTools(
                             "The id of the prop on the component definition. Matches Designer SDK propId.",
                           ),
                         value: z
-                          .any()
+                          .union([
+                            z.string(),
+                            z.number(),
+                            z.boolean(),
+                            z.null(),
+                            z.record(z.unknown()),
+                          ])
                           .describe(
                             "Value to set for this prop on the instance. Static primitive (string/number/boolean) or object for bindings. Pass null to reset this prop to its component default.",
                           ),

--- a/src/tools/rules.ts
+++ b/src/tools/rules.ts
@@ -60,6 +60,9 @@ export function registerRulesTools(server: McpServer) {
             `-- To close a component view and return to page view, use de_component_tool > close_component_view.\n` +
             `-- To rename a component, use de_component_tool > rename_component. Pass component_id and new_name.\n` +
             `-- To check if you are currently inside a component view, use de_component_tool > check_if_inside_component_view.\n` +
+            `-- To set per-instance property overrides on a component instance (e.g., a Heading instance's Text prop, a Button instance's label), use de_component_tool > set_component_instance_props. Pass the instance element id and an overrides array of { prop_id, value } entries. value may be a static primitive (string/number/boolean), a binding object, or null to reset a single prop to its component default. This only affects the targeted instance — it does not change component defaults or other instances. Prefer this over element_tool > set_text for props on component instances.\n` +
+            `-- To read per-instance prop values on a component instance, use de_component_tool > get_component_instance_props. Pass the instance element id. Optionally set resolved=true to get resolved values (bindings converted); default returns raw prop entries including a hasOverride flag per prop.\n` +
+            `-- To clear all per-instance overrides on a component instance back to component defaults, use de_component_tool > reset_component_instance_props. Pass the instance element id.\n` +
             `\n` +
             `Element Snapshot Tool Usage:\n` +
             `-- To get a visual snapshot of an element, section, or component, use element_snapshot_tool. Pass the element ID to capture its current visual state as an image.\n` +


### PR DESCRIPTION
Refs #96.

> Heads up: this PR was drafted by Claude Code, aimed at the pain point in #96 (no MCP surface for setting per-instance component props — `element_tool.set_text` errors on instances, and Data API `update_static_content` rejects the primary locale). Totally fine if the team prefers to implement this themselves; wanted to put a concrete shape on the table.

## What

Adds three actions to the existing `de_component_tool`, mirroring the Designer SDK's per-instance prop APIs on `ComponentElement`:

| Action | Wraps |
|---|---|
| `set_component_instance_props` | `setProps(entries)` |
| `get_component_instance_props` | `getProps()` / `getResolvedProps()` (via `resolved: true`) |
| `reset_component_instance_props` | `resetAllProps()` |

## Schema

```ts
set_component_instance_props: {
  id: { component: string; element: string };
  overrides: Array<{ prop_id: string; value: unknown | null }>; // null = reset this prop
}

get_component_instance_props: {
  id: { component: string; element: string };
  resolved?: boolean; // default false -> returns entries with hasOverride
}

reset_component_instance_props: {
  id: { component: string; element: string };
}
```

## Example

```json
{
  "name": "de_component_tool",
  "arguments": {
    "siteId": "…",
    "actions": [{
      "set_component_instance_props": {
        "id": { "component": "c_123", "element": "e_456" },
        "overrides": [{ "prop_id": "Text", "value": "Hello from MCP" }]
      }
    }]
  }
}
```

## ⚠️ Companion change required

The MCP server is a generic RPC forwarder (`src/modules/designerAppBridge.ts`). These actions are emitted verbatim over the socket to the **Webflow MCP Bridge App**, which needs a matching handler mapping each action to the SDK call. This PR ships the MCP-side schema only — a companion Bridge-App change is required for `#96` to actually close.

I intentionally used `Refs #96` rather than `Closes #96` for that reason.

## Testing

- `npm run build` clean (before and after).
- `npx tsc --noEmit` clean.
- Zod schema smoke cases covered: static string / number / boolean overrides, binding-object value, `null` reset-per-prop, empty-overrides rejected, `resolved: true`, reset-only action, empty-action rejected.
- No live Designer smoke test (couldn't attach to a session from where I'm working).
- Repo has no test framework; did not introduce one.

## Files

- `src/tools/deComponents.ts` — three new action keys on `de_component_tool`, refine guard updated.
- `src/tools/rules.ts` — three guidance lines added to `webflow_guide_tool`.