### PR TITLE
feat(style_tool): allow update_style by style_id

### DIFF
--- a/src/tools/deStyle.ts
+++ b/src/tools/deStyle.ts
@@ -86,8 +86,15 @@ export function registerDEStyleTools(server: McpServer, rpc: RPCType) {
                 .describe("Get all styles"),
               update_style: z
                 .object({
+                  style_id: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Exact style ID. When set, bypasses name/combo resolution.",
+                    ),
                   style_name: z
                     .string()
+                    .optional()
                     .describe("The name of the style to update"),
                   breakpoint_id: z
                     .enum([
@@ -153,6 +160,15 @@ export function registerDEStyleTools(server: McpServer, rpc: RPCType) {
                       "The parent style names to update the style for (for combo class)",
                     ),
                 })
+                .refine(
+                  (d) =>
+                    Boolean(d.style_id?.trim()) || Boolean(d.style_name?.trim()),
+                  {
+                    message:
+                      "update_style requires style_id or style_name (exactly one targeting strategy).",
+                    path: ["style_id"],
+                  },
+                )
                 .optional()
                 .describe("Update a style"),
               remove_style: z


### PR DESCRIPTION
## Problem

`query_styles` returns base utility `style_id` values (`isComboClass: false`). `update_style` requires `style_name` and resolves **combo shells** when names collide — agents cannot clear `text-wrap` on six goboon base utility IDs.

**Evidence site:** `67357e5b3470f7b3ed6b8017` (goboon)

| Base id (query) | Name-based `update_style` id | `isComboClass` |
|-----------------|------------------------------|----------------|
| `da317553-de32-cbab-b54f-45d9e7ce308e` | `d46038f7-…` | true |
| `8a893afb-5285-9a83-26aa-19bc009eee60` | `59e46359-…` | true |

Re-audit after six name-based clears: **6/6** base IDs still have `text-wrap`.

## Changes

- Add optional `style_id` to `update_style` zod object in `src/tools/deStyle.ts`
- Make `style_name` optional when `style_id` is set
- `.refine`: require `style_id` or `style_name`

Patch verified with `git apply` on `main` @ c4fa339.

## Verify before merge

- [ ] Designer bridge RPC accepts `style_id` on `update_style` and updates the **base** style, not a combo
- [ ] Regression: existing name-based updates unchanged
- [ ] Mirror optional `style_id` in published `style_tool` JSON schema if maintained separately

## Related

Boon internal patch kit: `tools/webflow-mcp-style-id-patch/` (not in this PR — upstream only).


Made with [Cursor](https://cursor.com)