### PR TITLE
[DEVPL-4067] Add data_custom_code_tool for freeform head/footer custom code

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -10,6 +10,7 @@ import {
   registerDEPagesTools,
   registerPagesTools,
   registerScriptsTools,
+  registerCustomCodeTools,
   registerSiteTools,
   registerDEStyleTools,
   registerDEVariableTools,
@@ -55,6 +56,7 @@ export function registerTools(
   registerComponentsTools(server, getClient);
   registerPagesTools(server, getClient);
   registerScriptsTools(server, getClient);
+  registerCustomCodeTools(server, getAccessToken);
   registerSiteTools(server, getClient);
   registerCommentsTools(server, getClient);
   registerEnterpriseTools(server, getClient);

--- a/src/tools/customCode.ts
+++ b/src/tools/customCode.ts
@@ -1,0 +1,263 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v3";
+import { requestOptions } from "../mcp";
+import {
+  type Content,
+  formatErrorResponse,
+  textContent,
+  toolResponse,
+} from "../utils";
+
+const WEBFLOW_API_BASE = "https://api.webflow.com";
+
+/**
+ * Thin authenticated wrapper over the freeform Custom Code Data API
+ * (GET/PUT /v2/{sites|pages}/:id/custom_code/freeform[/:location]). The SDK
+ * does not yet expose these endpoints, so we forward the user's OAuth token
+ * directly. Access control (scopes, the Custom Code entitlement, and the
+ * feature gate) is enforced API-side; this tool only relays the request.
+ */
+async function apiRequest(
+  method: string,
+  path: string,
+  getToken: () => string,
+  body?: unknown,
+): Promise<Content> {
+  const token = getToken();
+  const response = await fetch(`${WEBFLOW_API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...requestOptions.headers,
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw Object.assign(new Error(`HTTP ${response.status}`), {
+      name: "WebflowApiError",
+      status: response.status,
+      ...error,
+    });
+  }
+
+  // A PUT can respond with an empty body (204) — normalize to a success object.
+  const text = await response.text();
+  if (!text) {
+    return textContent({ success: true });
+  }
+  try {
+    return textContent(JSON.parse(text));
+  } catch {
+    return textContent(text);
+  }
+}
+
+type FreeformLocation = "head" | "footer";
+
+type CustomCodeAction = {
+  get_site_freeform_code?: { site_id: string; location?: FreeformLocation };
+  set_site_freeform_code?: {
+    site_id: string;
+    location: FreeformLocation;
+    content: string;
+  };
+  get_page_freeform_code?: {
+    page_id: string;
+    location?: FreeformLocation;
+    locale_id?: string;
+  };
+  set_page_freeform_code?: {
+    page_id: string;
+    location: FreeformLocation;
+    content: string;
+    locale_id?: string;
+  };
+};
+
+async function handleCustomCodeActions(
+  actions: CustomCodeAction[],
+  getToken: () => string,
+): Promise<Content[]> {
+  const result: Content[] = [];
+  for (const action of actions) {
+    if (action.get_site_freeform_code) {
+      const { site_id, location } = action.get_site_freeform_code;
+      const path = location
+        ? `/v2/sites/${site_id}/custom_code/freeform/${location}`
+        : `/v2/sites/${site_id}/custom_code/freeform`;
+      result.push(await apiRequest("GET", path, getToken));
+    }
+    if (action.set_site_freeform_code) {
+      const { site_id, location, content } = action.set_site_freeform_code;
+      result.push(
+        await apiRequest(
+          "PUT",
+          `/v2/sites/${site_id}/custom_code/freeform/${location}`,
+          getToken,
+          { content },
+        ),
+      );
+    }
+    if (action.get_page_freeform_code) {
+      const { page_id, location, locale_id } = action.get_page_freeform_code;
+      const base = location
+        ? `/v2/pages/${page_id}/custom_code/freeform/${location}`
+        : `/v2/pages/${page_id}/custom_code/freeform`;
+      const query = locale_id
+        ? `?localeId=${encodeURIComponent(locale_id)}`
+        : "";
+      result.push(await apiRequest("GET", `${base}${query}`, getToken));
+    }
+    if (action.set_page_freeform_code) {
+      const { page_id, location, content, locale_id } =
+        action.set_page_freeform_code;
+      const body: { content: string; localeId?: string } = { content };
+      if (locale_id) {
+        body.localeId = locale_id;
+      }
+      result.push(
+        await apiRequest(
+          "PUT",
+          `/v2/pages/${page_id}/custom_code/freeform/${location}`,
+          getToken,
+          body,
+        ),
+      );
+    }
+  }
+  return result;
+}
+
+export function registerCustomCodeTools(
+  server: McpServer,
+  getToken: () => string,
+) {
+  const locationSchema = z
+    .enum(["head", "footer"])
+    .describe(
+      "Freeform code location: 'head' (inside <head>) or 'footer' (before </body>).",
+    );
+
+  server.registerTool(
+    "data_custom_code_tool",
+    {
+      title: "Data Custom Code Tool",
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      description:
+        "Data tool - Manage freeform (raw HTML/JS) head and footer custom code on a site or page. This is distinct from registered scripts (see data_scripts_tool): freeform code is an arbitrary code block stored directly on the site or page. Reads require the sites/pages read scope; writes require the sites/pages write scope and the Custom Code entitlement.",
+      inputSchema: {
+        actions: z.array(
+          z
+            .object({
+              // GET https://api.webflow.com/v2/sites/:site_id/custom_code/freeform[/:location]
+              get_site_freeform_code: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  location: locationSchema
+                    .optional()
+                    .describe(
+                      "Optional. Omit to return both the head and footer blocks; pass 'head' or 'footer' for a single block.",
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get a site's freeform head/footer custom code. Requires the sites read scope.",
+                ),
+              // PUT https://api.webflow.com/v2/sites/:site_id/custom_code/freeform/:location
+              set_site_freeform_code: z
+                .object({
+                  site_id: z
+                    .string()
+                    .describe("Unique identifier for the site."),
+                  location: locationSchema,
+                  content: z
+                    .string()
+                    .describe(
+                      "The full raw code for this location. Atomically replaces the existing block. Subject to the site's custom-code character limit.",
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Set (atomically replace) a site's freeform head or footer custom code. Requires the sites write scope and the Custom Code entitlement.",
+                ),
+              // GET https://api.webflow.com/v2/pages/:page_id/custom_code/freeform[/:location]
+              get_page_freeform_code: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("Unique identifier for the page."),
+                  location: locationSchema
+                    .optional()
+                    .describe(
+                      "Optional. Omit to return both the head and footer blocks; pass 'head' or 'footer' for a single block.",
+                    ),
+                  locale_id: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Optional locale ID. If provided, must be the site's primary locale (page freeform code is single-locale today).",
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Get a page's freeform head/footer custom code. Requires the pages read scope.",
+                ),
+              // PUT https://api.webflow.com/v2/pages/:page_id/custom_code/freeform/:location
+              set_page_freeform_code: z
+                .object({
+                  page_id: z
+                    .string()
+                    .describe("Unique identifier for the page."),
+                  location: locationSchema,
+                  content: z
+                    .string()
+                    .describe(
+                      "The full raw code for this location. Atomically replaces the existing block. Subject to the site's custom-code character limit.",
+                    ),
+                  locale_id: z
+                    .string()
+                    .optional()
+                    .describe(
+                      "Optional locale ID. If provided, must be the site's primary locale (page freeform code is single-locale today).",
+                    ),
+                })
+                .optional()
+                .describe(
+                  "Set (atomically replace) a page's freeform head or footer custom code. Requires the pages write scope and the Custom Code entitlement.",
+                ),
+            })
+            .strict()
+            .refine(
+              (d) =>
+                [
+                  d.get_site_freeform_code,
+                  d.set_site_freeform_code,
+                  d.get_page_freeform_code,
+                  d.set_page_freeform_code,
+                ].filter(Boolean).length >= 1,
+              {
+                message:
+                  "Provide at least one of get_site_freeform_code, set_site_freeform_code, get_page_freeform_code, set_page_freeform_code.",
+              },
+            ),
+        ),
+      },
+    },
+    async ({ actions }) => {
+      try {
+        const result = await handleCustomCodeActions(actions, getToken);
+        return toolResponse(result);
+      } catch (error) {
+        return formatErrorResponse(error);
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ export { registerCmsTools } from "./cms";
 export { registerComponentsTools } from "./components";
 export { registerPagesTools } from "./pages";
 export { registerScriptsTools } from "./scripts";
+export { registerCustomCodeTools } from "./customCode";
 export { registerSiteTools } from "./sites";
 export { registerCommentsTools } from "./comments";
 export { registerEnterpriseTools } from "./enterprise";


### PR DESCRIPTION
## Summary

Adds a `data_custom_code_tool` that exposes Webflow's **freeform custom code** (raw `<head>` / footer code blocks on a site or page) through the MCP server. The Data API endpoints `/v2/{sites|pages}/:id/custom_code/freeform[/:location]` are live, but no MCP tool wrapped them, so MCP clients had no way to read or write freeform head/footer code.

> This is distinct from the existing `data_scripts_tool`, which manages *registered scripts* applied to a site/page. Freeform code is an arbitrary code block stored directly on the site or page.

## What's added

One `data_custom_code_tool` (actions array, consistent with the other data tools):

- `get_site_freeform_code` — GET a site's head/footer freeform code (omit `location` for both)
- `set_site_freeform_code` — PUT (atomic replace) a site's head or footer
- `get_page_freeform_code` — GET a page's head/footer freeform code (optional `locale_id`)
- `set_page_freeform_code` — PUT (atomic replace) a page's head or footer

## How it works

Mirrors the existing `data_workflows_tool`: a thin authenticated `fetch` to the Data API using the caller's OAuth token. All access control — read/write scopes, the Custom Code entitlement, and the feature gate — is enforced API-side, so this stays a thin wrapper with no SDK change.

## How to test

Prereqs: connect the MCP server to a client (Claude Desktop / Cursor / MCP Inspector) with a token that has `sites:read|write` + `pages:read|write` and a workspace/site with the Custom Code entitlement. Grab a `SITE_ID` and a `PAGE_ID` (e.g. via `data_sites_tool` / `data_pages_tool`).

**Natural-language prompts:**

1. `Read the freeform head and footer custom code on page PAGE_ID.`
2. `Add <meta name="robots" content="noindex"> to the head custom code on page PAGE_ID, then read it back to confirm.`
3. `Put a small console.log script in the footer custom code of page PAGE_ID.`
4. `Show the site-wide freeform head and footer code for site SITE_ID.`
5. `Add an Inter Google Font <link> tag to the site-wide head code for site SITE_ID.`
6. `Clear the footer code on page PAGE_ID by setting it to an empty string.`

**Direct tool calls (MCP Inspector):**

```json
{ "actions": [ { "get_page_freeform_code": { "page_id": "PAGE_ID" } } ] }
```
```json
{ "actions": [ { "set_page_freeform_code": { "page_id": "PAGE_ID", "location": "head", "content": "<meta name=\"robots\" content=\"noindex\">" } } ] }
```
```json
{ "actions": [ { "set_site_freeform_code": { "site_id": "SITE_ID", "location": "head", "content": "<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Inter&display=swap\">" } } ] }
```
```json
// batch: write then read back in one call
{ "actions": [
  { "set_page_freeform_code": { "page_id": "PAGE_ID", "location": "footer", "content": "<script>console.log('hello')</script>" } },
  { "get_page_freeform_code": { "page_id": "PAGE_ID", "location": "footer" } }
] }
```

**What to verify:**

- Round-trip: a `set_*` followed by a `get_*` returns the same `content`.
- `get_*` with no `location` returns both head and footer; with `location` returns just that block.
- Writes are atomic replaces (the previous content for that location is fully replaced).
- Error surfacing (returned cleanly via the tool's error handler, not a crash):
  - token missing `*:write` scope → scope/authorization error
  - site/workspace without the Custom Code entitlement → 402/forbidden
  - `set_page_freeform_code` with a non-primary `locale_id` → validation error (page freeform code is single-locale today)
  - `content` over the custom-code character limit → validation error
- At least one valid action per call is required (the schema rejects an empty action object).

## Testing (build)

- `npx tsc --noEmit` — passes, no type errors
- `npm run build` (tsup) — succeeds

(No test suite exists in this repo; verification is typecheck + build.)

## Follow-up

- The AI tool-reference doc that currently lists custom code as "Not Supported" lives outside this repo and should be updated separately.

## Jira

- [DEVPL-4067 — Tool: Page header & footer custom code](https://webflow.atlassian.net/browse/DEVPL-4067)
- [DEVPL-4351 — Page head/body custom code Data API](https://webflow.atlassian.net/browse/DEVPL-4351) (the underlying API this tool exposes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
