### PR TITLE
Archive webflow/mcp-server — README notice → public Beta MCP + community

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,27 @@ A Node.js server implementing Model Context Protocol (MCP) for Webflow using the
 [![npm shield](https://img.shields.io/npm/v/webflow-mcp-server)](https://www.npmjs.com/package/webflow-mcp-server)
 ![Webflow](https://img.shields.io/badge/webflow-%23146EF5.svg?style=for-the-badge&logo=webflow&logoColor=white)
 
-> ## ⚠️ This repository is archived
+> ## 📦 This repository — the open-source, self-hosted MCP server — is being archived
 >
-> `webflow-mcp-server` is no longer maintained, and issues are disabled.
+> **The Webflow MCP is not going away. We're investing in it more than ever.** The only thing changing is *how it's distributed.*
 >
-> **We're still investing heavily in the Webflow MCP** — active development has moved
-> to a separate repository, and the MCP is now available as a public **Beta**.
+> This repository, `webflow-mcp-server`, is the **open-source (OSS), self-hosted** MCP server — the package you download and run **locally** on your own machine. Webflow now provides a **fully hosted, remote MCP server** that you connect to directly over a URL, with **no local install or setup required** — and that hosted server is how customers use the Webflow MCP today.
 >
-> ### 🚀 Use the public Beta MCP — actively developed
+> Because everyone now connects through the hosted server, we're **consolidating onto it** and archiving this self-hosted OSS repository (it becomes read-only). To be explicit: this is a **distribution change, not a deprecation** of the Webflow MCP — the product is actively developed and growing.
 >
-> Get started (open to everyone): **https://developers.webflow.com/mcp/installing/beta**
+> ### 🚀 Use the hosted Webflow MCP (recommended — actively developed)
+>
+> - Get started, no local setup required: **https://developers.webflow.com/mcp**
+> - Try the public Beta: **https://developers.webflow.com/mcp/installing/beta**
 >
 > ### 📖 Docs & changelog
 >
 > - MCP docs: https://developers.webflow.com/mcp
 > - Changelog: https://developers.webflow.com/home/changelog?filter=MCP
 >
-> ### 💬 Engagement & bug reports
+> ### 💬 Bugs, issues & engagement
 >
-> We're no longer tracking issues here — please use our community instead:
+> GitHub issues on this repository are disabled. Please bring bugs, questions, and feedback to our community:
 > **https://community.webflow.com**
 > <!-- TODO: confirm community.webflow.com is live before merging — it was not loading at time of writing. -->
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ A Node.js server implementing Model Context Protocol (MCP) for Webflow using the
 [![npm shield](https://img.shields.io/npm/v/webflow-mcp-server)](https://www.npmjs.com/package/webflow-mcp-server)
 ![Webflow](https://img.shields.io/badge/webflow-%23146EF5.svg?style=for-the-badge&logo=webflow&logoColor=white)
 
-> ## 📦 This repository — the open-source, self-hosted MCP server — is being archived
+> ## 📦 This repository — Webflow's open-source (OSS) MCP server — is being archived
 >
 > **The Webflow MCP is not going away. We're investing in it more than ever.** The only thing changing is *how it's distributed.*
 >
-> This repository, `webflow-mcp-server`, is the **open-source (OSS), self-hosted** MCP server — the package you download and run **locally** on your own machine. Webflow now provides a **fully hosted, remote MCP server** that you connect to directly over a URL, with **no local install or setup required** — and that hosted server is how customers use the Webflow MCP today.
+> This repository, `webflow/mcp-server`, is **Webflow's open-source (OSS) MCP server**. Webflow also runs a **hosted, remote MCP server** at `https://mcp.webflow.com` that you connect to directly — and that hosted server is how customers use the Webflow MCP today. Ongoing development happens against the hosted service, in a separate repository.
 >
-> Because everyone now connects through the hosted server, we're **consolidating onto it** and archiving this self-hosted OSS repository (it becomes read-only). To be explicit: this is a **distribution change, not a deprecation** of the Webflow MCP — the product is actively developed and growing.
+> Because everyone now connects through the hosted server, we're **consolidating onto it** and archiving this open-source repository (it becomes read-only). To be explicit: this is a **distribution change, not a deprecation** of the Webflow MCP — the product is actively developed and growing.
 >
 > ### 🚀 Use the hosted Webflow MCP (recommended — actively developed)
 >

--- a/README.md
+++ b/README.md
@@ -5,6 +5,28 @@ A Node.js server implementing Model Context Protocol (MCP) for Webflow using the
 [![npm shield](https://img.shields.io/npm/v/webflow-mcp-server)](https://www.npmjs.com/package/webflow-mcp-server)
 ![Webflow](https://img.shields.io/badge/webflow-%23146EF5.svg?style=for-the-badge&logo=webflow&logoColor=white)
 
+> ## ⚠️ This repository is archived
+>
+> `webflow-mcp-server` is no longer maintained, and issues are disabled.
+>
+> **We're still investing heavily in the Webflow MCP** — active development has moved
+> to a separate repository, and the MCP is now available as a public **Beta**.
+>
+> ### 🚀 Use the public Beta MCP — actively developed
+>
+> Get started (open to everyone): **https://developers.webflow.com/mcp/installing/beta**
+>
+> ### 📖 Docs & changelog
+>
+> - MCP docs: https://developers.webflow.com/mcp
+> - Changelog: https://developers.webflow.com/home/changelog?filter=MCP
+>
+> ### 💬 Engagement & bug reports
+>
+> We're no longer tracking issues here — please use our community instead:
+> **https://community.webflow.com**
+> <!-- TODO: confirm community.webflow.com is live before merging — it was not loading at time of writing. -->
+
 ## Prerequisites
 
 - [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)


### PR DESCRIPTION
## Summary

This repo (`webflow-mcp-server`) is the **open-source, self-hosted** Webflow MCP server — the package you run locally. Webflow now runs a **hosted, remote** MCP server that customers connect to directly, and that hosted server is how the Webflow MCP is used today. We're consolidating onto the hosted server, so this OSS repo is being archived.

This PR adds a README notice that makes that distinction explicit and redirects visitors to the hosted MCP, docs/changelog, and the community.

## ⛔ Messaging — pending sign-off (do not merge yet)

Per #team-devrel feedback, the wording must not imply the Webflow MCP is deprecated:
- Reframed "no longer maintained / issues disabled" → the **OSS/self-hosted distribution** is being retired; the **hosted server is how customers use the MCP**; this is a **distribution change, not a deprecation**.
- Labeled as **OSS / self-hosted**, not generically "Webflow MCP".
- Verbose + explicit.

Needs sign-off from DevRel + dev marketing before merge (and a possible Dev Newsletter note).

## Before merging
- Confirm **community.webflow.com** is live — it's a placeholder (TODO comment beside it in the README).

## After merging
- Archive the repo: `gh repo archive webflow/mcp-server` (also disables issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
